### PR TITLE
Fixes #41 - Added Confirmation Dialog

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.signing.pgp.web/WEB-INF/views/managed/index.jsp
+++ b/bundles/org.eclipse.packagedrone.repo.signing.pgp.web/WEB-INF/views/managed/index.jsp
@@ -50,32 +50,43 @@ pageContext.setAttribute ( "TAG", ServiceController.ACTION_TAG_PGP );
             	</ul>
             </td>
             <td>
-                <a class="btn btn-danger" data-toggle="modal" data-target='<c:out value="#deleteConfirmation${fn:escapeXml(entry.id)}"></c:out>'><span class="glyphicon glyphicon-trash"></span></a>
-
-                <!-- Confirmation dialog -->
-                <div class="modal fade" id="<c:out value="deleteConfirmation${fn:escapeXml(entry.id)}"></c:out>" tabindex="-1" role="dialog">
-                    <div class="modal-dialog modal-sm" role="document">
-                        <div class="modal-content">
-                              <div class="modal-header">
-                                  <h4 class="modal-title">Are you sure?</h4>
-                              </div>
-                              <div class="modal-body">
-                                  <p>You are about to delete this PGP Key. This action <strong>cannot be undone</strong>.</p>
-                                  <p>Do you want to proceed?</p>
-                              </div>
-                              <div class="modal-footer">
-                                  <a type="button" class="btn btn-default" data-dismiss="modal">Cancel</a>
-                                  <a type="button" class="btn btn-danger" href="<c:url value='/pgp.sign.managed/${fn:escapeXml(entry.id) }/delete'/>">Delete</a>
-                              </div>
-                        </div>
-                    </div>
-                </div>
-
+                <a class="btn btn-danger" data-key-id="${fn:escapeXml(entry.id)}" data-toggle="modal" data-target="#confirmationDialog">
+                    <span class="glyphicon glyphicon-trash"></span>
+                </a>
             </td>
         </tr>
     </c:forEach>
     </tbody>
 </table>
+
+<!-- Confirmation dialog -->
+<div class="modal fade" id="confirmationDialog" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+              <div class="modal-header">
+                  <h4 class="modal-title">Are you sure?</h4>
+              </div>
+              <div class="modal-body">
+                  <p>You are about to delete this PGP Key. This action <strong>cannot be undone</strong>.</p>
+                  <p>Do you want to proceed?</p>
+              </div>
+              <div class="modal-footer">
+                  <a type="button" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                  <a type="button" class="btn btn-danger" id="confirmDeleteBtn">Delete</a>
+              </div>
+        </div>
+    </div>
+</div>
+
+<!-- Dynamically updates the delete button href to the correct Key -->
+<script type="text/javascript">
+$("#confirmationDialog").on("show.bs.modal", function(event) {
+    var button = $(event.relatedTarget);
+    var id = button.data("key-id");
+    var modal = $(this);
+    modal.find("#confirmDeleteBtn").attr('href', '/pgp.sign.managed/' + id + '/delete');
+})
+</script>
 
 </div>
 

--- a/bundles/org.eclipse.packagedrone.repo.signing.pgp.web/WEB-INF/views/managed/index.jsp
+++ b/bundles/org.eclipse.packagedrone.repo.signing.pgp.web/WEB-INF/views/managed/index.jsp
@@ -50,7 +50,27 @@ pageContext.setAttribute ( "TAG", ServiceController.ACTION_TAG_PGP );
             	</ul>
             </td>
             <td>
-                <a class="btn btn-danger" href="<c:url value="/pgp.sign.managed/${fn:escapeXml(entry.id) }/delete"/>"><span class="glyphicon glyphicon-trash"></span></a>
+                <a class="btn btn-danger" data-toggle="modal" data-target='<c:out value="#deleteConfirmation${fn:escapeXml(entry.id)}"></c:out>'><span class="glyphicon glyphicon-trash"></span></a>
+
+                <!-- Confirmation dialog -->
+                <div class="modal fade" id="<c:out value="deleteConfirmation${fn:escapeXml(entry.id)}"></c:out>" tabindex="-1" role="dialog">
+                    <div class="modal-dialog modal-sm" role="document">
+                        <div class="modal-content">
+                              <div class="modal-header">
+                                  <h4 class="modal-title">Are you sure?</h4>
+                              </div>
+                              <div class="modal-body">
+                                  <p>You are about to delete this PGP Key. This action <strong>cannot be undone</strong>.</p>
+                                  <p>Do you want to proceed?</p>
+                              </div>
+                              <div class="modal-footer">
+                                  <a type="button" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                                  <a type="button" class="btn btn-danger" href="<c:url value='/pgp.sign.managed/${fn:escapeXml(entry.id) }/delete'/>">Delete</a>
+                              </div>
+                        </div>
+                    </div>
+                </div>
+
             </td>
         </tr>
     </c:forEach>


### PR DESCRIPTION
Added modal reference for each delete row.

![implementation](https://cloud.githubusercontent.com/assets/2225536/13309498/1e00185a-db5c-11e5-896d-a3fa6d6f370f.png)

The downside of this solution is that if we have a long list of keys, we will have a long list of duplicated dialogs since there's a modal for each row.

One improvement of this solution would be using javascript to dinamically build a unique modal with the proper href on the delete button. Something like:

On index.jsp
```{html}
<a class="btn btn-danger" onclick="showConfirmationDialogFor('${fn:escapeXml(entry.id)')"><span class="glyphicon glyphicon-trash"></span></a>
```

In some JS file...
```{javascript}
var showConfirmationDialogFor = function(id) {
    var deleteUrl = "/pgp.sign.managed/" + id + "/delete";
    var modalEmbeddedHtml = "<div class'...."
         + "...more embedded modal HTML code..."
         + "<a type='button' class='btn btn-danger' href='" + deleteUrl + "'>Delete</a>"
         + "...more embedded modal HTML code..."
         + "</div>";
    $(modalEmbeddedHtml).modal();
}
```

I am honestly not a big fan from the second approach because embedded HTML code in JS is terrible for understanding and debugging :bomb::boom::sob: . I only suggest this idea if really necessary.

If you have any other suggestion, feel free to talk about and I can adjust my pull request :smile"

Signed-off-by: Jeanderson Candido <jeandersonbc@gmail.com>