### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Generator.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Generator.java
@@ -2075,7 +2075,7 @@ class Generator {
                         if (isTagFile) {
                             String verS = ctxt.getTagInfo().
                                     getTagLibrary().getRequiredVersion();
-                            Double version = Double.valueOf(verS).doubleValue();
+                            Double version = Double.parseDouble(verS);
                             if (version < 2.1) {
                                 unescapePound = true;
                             }

--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/JspUtil.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/JspUtil.java
@@ -454,7 +454,7 @@ public class JspUtil {
 	    if (s.equalsIgnoreCase("yes")) {
 		b = true;
 	    } else {
-		b = Boolean.valueOf(s).booleanValue();
+		b = Boolean.parseBoolean(s);
 	    }
 	}
 	return b;

--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Node.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Node.java
@@ -1439,7 +1439,7 @@ abstract class Node implements TagConstants {
             super(qName, localName, attrs, nonTaglibXmlnsAttrs, taglibAttrs,
                   start, parent);
 
-            this.jspVersion = Double.valueOf(jspVersion).doubleValue();
+            this.jspVersion = Double.parseDouble(jspVersion);
 	    this.uri = uri;
 	    this.prefix = prefix;
 	    this.tagInfo = tagInfo;
@@ -1483,7 +1483,7 @@ abstract class Node implements TagConstants {
             super(qName, localName, attrs, nonTaglibXmlnsAttrs, taglibAttrs,
                   start, parent);
 
-            this.jspVersion = Double.valueOf(jspVersion).doubleValue();
+            this.jspVersion = Double.parseDouble(jspVersion);
 	    this.uri = uri;
 	    this.prefix = prefix;
 	    this.tagFileInfo = tagFileInfo;

--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/PageInfo.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/PageInfo.java
@@ -510,7 +510,7 @@ public class PageInfo {
                 else
 		    err.jspError(n, "jsp.error.page.invalid.buffer");
 	    try {
-		Integer k = new Integer(value.substring(0, value.length()-2));
+		Integer k = Integer.parseInt(value.substring(0, value.length()-2));
 		buffer = k.intValue() * 1024;
 	    } catch (NumberFormatException e) {
                 if (n == null) 

--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Validator.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/compiler/Validator.java
@@ -746,7 +746,7 @@ class Validator {
                 if (ctxt.isTagFile()) {
                     String versionString =
                         ctxt.getTagInfo().getTagLibrary().getRequiredVersion();
-                    Double version = Double.valueOf(versionString).doubleValue();
+                    Double version = Double.parseDouble(versionString);
                     if (version < 2.1) {
                         return;
                     }

--- a/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/runtime/JspRuntimeLibrary.java
+++ b/bundles/org.apache.jasper.glassfish/src/org/apache/jasper/runtime/JspRuntimeLibrary.java
@@ -162,14 +162,14 @@ public class JspRuntimeLibrary {
 	if (s == null || s.length() == 0)
 	    return false;
 	else
-	    return Boolean.valueOf(s).booleanValue();
+	    return Boolean.parseBoolean(s);
     }
 
     public static byte coerceToByte(String s) {
 	if (s == null || s.length() == 0)
 	    return (byte) 0;
 	else
-	    return Byte.valueOf(s).byteValue();
+	    return Byte.parseByte(s);
     }
 
     public static char coerceToChar(String s) {
@@ -185,35 +185,35 @@ public class JspRuntimeLibrary {
 	if (s == null || s.length() == 0)
 	    return (double) 0;
 	else
-	    return Double.valueOf(s).doubleValue();
+	    return Double.parseDouble(s);
     }
 
     public static float coerceToFloat(String s) {
 	if (s == null || s.length() == 0)
 	    return (float) 0;
 	else
-	    return Float.valueOf(s).floatValue();
+	    return Float.parseFloat(s);
     }
 
     public static int coerceToInt(String s) {
 	if (s == null || s.length() == 0)
 	    return 0;
 	else
-	    return Integer.valueOf(s).intValue();
+	    return Integer.parseInt(s);
     }
 
     public static short coerceToShort(String s) {
 	if (s == null || s.length() == 0)
 	    return (short) 0;
 	else
-	    return Short.valueOf(s).shortValue();
+	    return Short.parseShort(s);
     }
 
     public static long coerceToLong(String s) {
 	if (s == null || s.length() == 0)
 	    return (long) 0;
 	else
-	    return Long.valueOf(s).longValue();
+	    return Long.parseLong(s);
     }
 
     @SuppressWarnings("unchecked")
@@ -554,12 +554,12 @@ public class JspRuntimeLibrary {
 	    } else if (t.equals(double.class)) {
 		double[] tmpval = new double[values.length];
 		for (int i = 0 ; i < values.length; i++)
-		    tmpval[i] = Double.valueOf(values[i]).doubleValue();
+		    tmpval[i] = Double.parseDouble(values[i]);
 		method.invoke (bean, new Object[] {tmpval});
 	    } else if (t.equals(float.class)) {
 		float[] tmpval = new float[values.length];
 		for (int i = 0 ; i < values.length; i++)
-		    tmpval[i] = Float.valueOf(values[i]).floatValue();
+		    tmpval[i] = Float.parseFloat(values[i]);
 		method.invoke (bean, new Object[] {tmpval});
 	    } else if (t.equals(char.class)) {
 		char[] tmpval = new char[values.length];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for String conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat