### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/bundles/org.eclipse.packagedrone.job/src/org/eclipse/packagedrone/job/State.java
+++ b/bundles/org.eclipse.packagedrone.job/src/org/eclipse/packagedrone/job/State.java
@@ -38,6 +38,8 @@ public enum State
                 return RUNNING;
             case 2:
                 return COMPLETE;
+            default:
+                break;
         }
         throw new IllegalArgumentException ( String.format ( "State %s is unknown", id ) );
     }

--- a/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/servlet/AptServlet.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/servlet/AptServlet.java
@@ -202,6 +202,8 @@ public class AptServlet extends AbstractChannelServiceServlet
                 case "Release":
                 case "Release.gpg":
                     return new ChannelCacheHandler ( channel, new MetaKey ( AptChannelAspectFactory.ID, String.format ( "dists/%s/%s", cfg.getDistribution (), component ) ) );
+                default:
+                    break;
             }
 
             // TODO: handle all components when implemented
@@ -259,6 +261,8 @@ public class AptServlet extends AbstractChannelServiceServlet
                     return new ChannelCacheHandler ( channel, new MetaKey ( AptChannelAspectFactory.ID, String.format ( "dists/%s/%s/%s/%s", cfg.getDistribution (), component, type, file ) ) );
                 case "Packages.bz2":
                     return new ChannelCacheHandler ( channel, new MetaKey ( AptChannelAspectFactory.ID, String.format ( "dists/%s/%s/%s/%s", cfg.getDistribution (), component, type, file ) ) );
+                default:
+                    break;
             }
         }
 

--- a/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/NodeAdapter.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/NodeAdapter.java
@@ -71,6 +71,8 @@ public class NodeAdapter implements JsonSerializer<Node>, JsonDeserializer<Node>
                 return ctx.deserialize ( val, DataNode.class );
             case "ArtifactNode":
                 return ctx.deserialize ( val, ArtifactNode.class );
+            default:
+                break;
         }
 
         return null;

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/servlet/ZippedHandler.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/servlet/ZippedHandler.java
@@ -78,6 +78,8 @@ public class ZippedHandler implements Handler
                 case "eclipse.feature":
                     stream ( zos, this.channel, a, "features/" + name );
                     break;
+                default:
+                    break;
             }
         }
 

--- a/bundles/org.eclipse.packagedrone.repo.aspect.upgrade/src/org/eclipse/packagedrone/repo/aspect/upgrade/UpgradeTaskProvider.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.upgrade/src/org/eclipse/packagedrone/repo/aspect/upgrade/UpgradeTaskProvider.java
@@ -115,6 +115,8 @@ public class UpgradeTaskProvider extends DefaultTaskProvider implements EventHan
             case ServiceEvent.REGISTERED:
                 refresh ();
                 break;
+            default:
+                break;
         }
     }
 

--- a/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/Helper.java
+++ b/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/Helper.java
@@ -84,6 +84,8 @@ public final class Helper
                         return true;
                     }
                     break;
+                default:
+                    break;
             }
         }
         return false;

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/ParserHelper.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/ParserHelper.java
@@ -124,6 +124,8 @@ public final class ParserHelper
                             case "qualifier":
                                 qualifier = reader.peek () == JsonToken.NULL ? null : reader.nextString ();
                                 break;
+                            default:
+                                break;
                         }
                     }
                     reader.endObject ();

--- a/bundles/org.eclipse.packagedrone.web.common/src/org/eclipse/packagedrone/web/common/tags/Functions.java
+++ b/bundles/org.eclipse.packagedrone.web.common/src/org/eclipse/packagedrone/web/common/tags/Functions.java
@@ -60,6 +60,8 @@ public class Functions
             case LINK:
                 value = "link";
                 break;
+            default:
+                break;
         }
 
         if ( value != null && prefix != null )

--- a/bundles/org.eclipse.packagedrone.web/src/org/eclipse/packagedrone/web/controller/ControllerTracker.java
+++ b/bundles/org.eclipse.packagedrone.web/src/org/eclipse/packagedrone/web/controller/ControllerTracker.java
@@ -47,6 +47,8 @@ public class ControllerTracker implements RequestHandlerFactory
                 case ServiceEvent.UNREGISTERING:
                     handleRemovedService ( event.getServiceReference () );
                     break;
+                default:
+                    break;
             }
         }
     };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat