### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/aspect/internal/RepoBuilder.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/aspect/internal/RepoBuilder.java
@@ -196,7 +196,7 @@ public class RepoBuilder
             final Map<String, String> values = new HashMap<> ( packageInfo.getControl () );
 
             values.put ( "Filename", packageInfo.getPoolName () );
-            values.put ( "Size", Long.toString(packageInfo.getFileSize ()) );
+            values.put ( "Size", Long.toString ( packageInfo.getFileSize () ) );
 
             if ( !values.containsKey ( "Description-md5" ) )
             {
@@ -487,7 +487,7 @@ public class RepoBuilder
 
     /**
      * Write field only when the value is set
-     *
+     * 
      * @param writer
      *            the writer to use
      * @param fieldName
@@ -505,15 +505,14 @@ public class RepoBuilder
 
     /**
      * Write a field
-     *
+     * 
      * @param writer
      *            the writer to use
      * @param fieldName
      *            the field name
      * @param value
      *            the value, should not be <code>null</code> since this would
-     *            cause the string
-     *            <q>null</q> in the file.
+     *            cause the string <q>null</q> in the file.
      */
     protected static void write ( final StringWriter writer, final String fieldName, final String value )
     {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/aspect/internal/RepoBuilder.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.deb/src/org/eclipse/packagedrone/repo/adapter/deb/aspect/internal/RepoBuilder.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131 
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.deb.aspect.internal;
 
@@ -195,7 +196,7 @@ public class RepoBuilder
             final Map<String, String> values = new HashMap<> ( packageInfo.getControl () );
 
             values.put ( "Filename", packageInfo.getPoolName () );
-            values.put ( "Size", "" + packageInfo.getFileSize () );
+            values.put ( "Size", Long.toString(packageInfo.getFileSize ()) );
 
             if ( !values.containsKey ( "Description-md5" ) )
             {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractRepositoryProcessor.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractRepositoryProcessor.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.p2.internal.aspect;
 
@@ -47,7 +48,7 @@ public abstract class AbstractRepositoryProcessor extends AbstractDocumentProces
 
         this.properties.putAll ( additionalProperties );
 
-        this.properties.put ( "p2.timestamp", "" + System.currentTimeMillis () );
+        this.properties.put ( "p2.timestamp", Long.toString(System.currentTimeMillis ()) );
 
         if ( compressed )
         {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractRepositoryProcessor.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractRepositoryProcessor.java
@@ -48,7 +48,7 @@ public abstract class AbstractRepositoryProcessor extends AbstractDocumentProces
 
         this.properties.putAll ( additionalProperties );
 
-        this.properties.put ( "p2.timestamp", Long.toString(System.currentTimeMillis ()) );
+        this.properties.put ( "p2.timestamp", Long.toString ( System.currentTimeMillis () ) );
 
         if ( compressed )
         {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractWriter.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractWriter.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.p2.internal.aspect;
 
@@ -55,7 +56,7 @@ public abstract class AbstractWriter
             this.properties.put ( "p2.compressed", "true" );
         }
 
-        this.properties.put ( "p2.timestamp", "" + timestamp.toEpochMilli () );
+        this.properties.put ( "p2.timestamp", Long.toString(timestamp.toEpochMilli ()) );
 
         if ( additionalProperties != null )
         {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractWriter.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/AbstractWriter.java
@@ -56,7 +56,7 @@ public abstract class AbstractWriter
             this.properties.put ( "p2.compressed", "true" );
         }
 
-        this.properties.put ( "p2.timestamp", Long.toString(timestamp.toEpochMilli ()) );
+        this.properties.put ( "p2.timestamp", Long.toString ( timestamp.toEpochMilli () ) );
 
         if ( additionalProperties != null )
         {

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/ExtractorImpl.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/ExtractorImpl.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131     
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.p2.internal.aspect;
 
@@ -109,7 +110,7 @@ public class ExtractorImpl implements Extractor
             metadata.put ( P2RepoConstants.KEY_FRAGMENT_DATA.getKey (), sw.toString () );
             metadata.put ( P2RepoConstants.KEY_FRAGMENT_KEYS.getKey (), StringHelper.join ( keys, ENTRY_DELIMITER ) );
             metadata.put ( P2RepoConstants.KEY_FRAGMENT_MD5.getKey (), StringHelper.join ( sums, ENTRY_DELIMITER ) );
-            metadata.put ( P2RepoConstants.KEY_FRAGMENT_COUNT.getKey (), "" + count );
+            metadata.put ( P2RepoConstants.KEY_FRAGMENT_COUNT.getKey (), Integer.toString(count) );
         }
     }
 
@@ -132,7 +133,7 @@ public class ExtractorImpl implements Extractor
             }
 
             metadata.put ( P2RepoConstants.KEY_FRAGMENT_DATA.getKey (), sw.toString () );
-            metadata.put ( P2RepoConstants.KEY_FRAGMENT_COUNT.getKey (), "" + count );
+            metadata.put ( P2RepoConstants.KEY_FRAGMENT_COUNT.getKey (), Integer.toString(count) );
         }
     }
 

--- a/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/P2RepoChannelAggregator.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.p2/src/org/eclipse/packagedrone/repo/adapter/p2/internal/aspect/P2RepoChannelAggregator.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.p2.internal.aspect;
 
@@ -52,7 +53,7 @@ public class P2RepoChannelAggregator implements ChannelAggregator
 
             if ( lastTimestamp != null )
             {
-                result.put ( "last-change", "" + lastTimestamp.getTime () );
+                result.put ( "last-change", Long.toString(lastTimestamp.getTime ()) );
                 result.put ( "last-change-string", DATE_FORMAT.format ( lastTimestamp.getTime () ) );
             }
 

--- a/bundles/org.eclipse.packagedrone.repo.adapter.r5/src/org/eclipse/packagedrone/repo/adapter/r5/RepositoryCreator.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.r5/src/org/eclipse/packagedrone/repo/adapter/r5/RepositoryCreator.java
@@ -229,7 +229,7 @@ public class RepositoryCreator
             final Map<String, String> reqs = new HashMap<> ();
 
             final String filter = and ( //
-                    pair ( "osgi.wiring.bundle", br.getId () ), //
+            pair ( "osgi.wiring.bundle", br.getId () ), //
                     versionRange ( "bundle-version", br.getVersionRange () ) //
             );
 
@@ -275,7 +275,7 @@ public class RepositoryCreator
             final Map<String, String> reqs = new HashMap<> ();
 
             final String filter = and ( //
-                    pair ( "osgi.wiring.package", pi.getName () ), //
+            pair ( "osgi.wiring.package", pi.getName () ), //
                     versionRange ( "version", pi.getVersionRange () ) //
             );
 
@@ -342,7 +342,7 @@ public class RepositoryCreator
         for ( final BundleRequirement br : bi.getBundleRequirements () )
         {
             final String filter = and ( //
-                    pair ( "symbolicname", br.getId () ), //
+            pair ( "symbolicname", br.getId () ), //
                     versionRange ( "version", br.getVersionRange () ) //
             );
 
@@ -375,7 +375,7 @@ public class RepositoryCreator
         for ( final PackageImport pi : bi.getPackageImports () )
         {
             final String filter = and ( //
-                    pair ( "package", pi.getName () ), //
+            pair ( "package", pi.getName () ), //
                     versionRange ( "version", pi.getVersionRange () ) //
             );
 
@@ -412,9 +412,9 @@ public class RepositoryCreator
 
         writer.writeAttribute ( "name", id );
         writer.writeAttribute ( "filter", filter );
-        writer.writeAttribute ( "extend", Boolean.toString(extend) );
-        writer.writeAttribute ( "multiple", Boolean.toString(multiple) );
-        writer.writeAttribute ( "optional", Boolean.toString(optional) );
+        writer.writeAttribute ( "extend", Boolean.toString ( extend ) );
+        writer.writeAttribute ( "multiple", Boolean.toString ( multiple ) );
+        writer.writeAttribute ( "optional", Boolean.toString ( optional ) );
 
         writer.writeCharacters ( text );
 
@@ -610,7 +610,7 @@ public class RepositoryCreator
 
         xsw.writeStartElement ( "repository" );
         xsw.writeDefaultNamespace ( "http://www.osgi.org/xmlns/repository/v1.0.0" );
-        xsw.writeAttribute ( "increment", Long.toString(System.currentTimeMillis ()) );
+        xsw.writeAttribute ( "increment", Long.toString ( System.currentTimeMillis () ) );
         xsw.writeAttribute ( "name", this.name );
 
         xsw.writeCharacters ( "\n\n" );

--- a/bundles/org.eclipse.packagedrone.repo.adapter.r5/src/org/eclipse/packagedrone/repo/adapter/r5/RepositoryCreator.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.r5/src/org/eclipse/packagedrone/repo/adapter/r5/RepositoryCreator.java
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
  *     Julius Fingerle - fix a few repository generations issues
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.r5;
 
@@ -411,9 +412,9 @@ public class RepositoryCreator
 
         writer.writeAttribute ( "name", id );
         writer.writeAttribute ( "filter", filter );
-        writer.writeAttribute ( "extend", "" + extend );
-        writer.writeAttribute ( "multiple", "" + multiple );
-        writer.writeAttribute ( "optional", "" + optional );
+        writer.writeAttribute ( "extend", Boolean.toString(extend) );
+        writer.writeAttribute ( "multiple", Boolean.toString(multiple) );
+        writer.writeAttribute ( "optional", Boolean.toString(optional) );
 
         writer.writeCharacters ( text );
 
@@ -609,7 +610,7 @@ public class RepositoryCreator
 
         xsw.writeStartElement ( "repository" );
         xsw.writeDefaultNamespace ( "http://www.osgi.org/xmlns/repository/v1.0.0" );
-        xsw.writeAttribute ( "increment", "" + System.currentTimeMillis () );
+        xsw.writeAttribute ( "increment", Long.toString(System.currentTimeMillis ()) );
         xsw.writeAttribute ( "name", this.name );
 
         xsw.writeCharacters ( "\n\n" );

--- a/bundles/org.eclipse.packagedrone.repo.adapter.rpm/src/org/eclipse/packagedrone/repo/adapter/rpm/yum/RepositoryCreator.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.rpm/src/org/eclipse/packagedrone/repo/adapter/rpm/yum/RepositoryCreator.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.rpm.yum;
 
@@ -325,9 +326,9 @@ public class RepositoryCreator
 
         public void close () throws IOException
         {
-            this.primaryRoot.setAttribute ( "packages", "" + this.count );
-            this.filelistsRoot.setAttribute ( "packages", "" + this.count );
-            this.otherRoot.setAttribute ( "packages", "" + this.count );
+            this.primaryRoot.setAttribute ( "packages", Long.toString(this.count) );
+            this.filelistsRoot.setAttribute ( "packages", Long.toString(this.count) );
+            this.otherRoot.setAttribute ( "packages", Long.toString(this.count) );
 
             try
             {
@@ -442,7 +443,7 @@ public class RepositoryCreator
         final Element root = doc.createElementNS ( "http://linux.duke.edu/metadata/repo", "repomd" );
         doc.appendChild ( root );
 
-        root.setAttribute ( "revision", "" + now / 1000 );
+        root.setAttribute ( "revision", Long.toString(now / 1000) );
 
         addDataFile ( root, this.primaryStreamBuilder, this.primaryUniqueName, "primary", now );
         addDataFile ( root, this.filelistsStreamBuilder, this.filelistsUniqueName, "filelists", now );

--- a/bundles/org.eclipse.packagedrone.repo.adapter.rpm/src/org/eclipse/packagedrone/repo/adapter/rpm/yum/RepositoryCreator.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.rpm/src/org/eclipse/packagedrone/repo/adapter/rpm/yum/RepositoryCreator.java
@@ -326,9 +326,9 @@ public class RepositoryCreator
 
         public void close () throws IOException
         {
-            this.primaryRoot.setAttribute ( "packages", Long.toString(this.count) );
-            this.filelistsRoot.setAttribute ( "packages", Long.toString(this.count) );
-            this.otherRoot.setAttribute ( "packages", Long.toString(this.count) );
+            this.primaryRoot.setAttribute ( "packages", Long.toString ( this.count ) );
+            this.filelistsRoot.setAttribute ( "packages", Long.toString ( this.count ) );
+            this.otherRoot.setAttribute ( "packages", Long.toString ( this.count ) );
 
             try
             {
@@ -443,7 +443,7 @@ public class RepositoryCreator
         final Element root = doc.createElementNS ( "http://linux.duke.edu/metadata/repo", "repomd" );
         doc.appendChild ( root );
 
-        root.setAttribute ( "revision", Long.toString(now / 1000) );
+        root.setAttribute ( "revision", Long.toString ( now / 1000 ) );
 
         addDataFile ( root, this.primaryStreamBuilder, this.primaryUniqueName, "primary", now );
         addDataFile ( root, this.filelistsStreamBuilder, this.filelistsUniqueName, "filelists", now );

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.aspect.common.p2;
 
@@ -675,7 +676,7 @@ public class InstallableUnit
     public static void writeXml ( final XMLStreamWriter xsw, final List<InstallableUnit> ius ) throws XMLStreamException
     {
         xsw.writeStartElement ( "units" );
-        xsw.writeAttribute ( "size", "" + ius.size () );
+        xsw.writeAttribute ( "size", Integer.toString(ius.size ()) );
         for ( final InstallableUnit iu : ius )
         {
             iu.writeXmlForUnit ( xsw );
@@ -709,7 +710,7 @@ public class InstallableUnit
         xsw.writeStartElement ( "unit" );
         xsw.writeAttribute ( "id", this.id );
         xsw.writeAttribute ( "version", "" + this.version );
-        xsw.writeAttribute ( "singleton", "" + this.singleton );
+        xsw.writeAttribute ( "singleton", Boolean.toString(this.singleton) );
 
         {
             xsw.writeEmptyElement ( "update" );
@@ -720,7 +721,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "properties" );
-            xsw.writeAttribute ( "size", "" + this.properties.size () );
+            xsw.writeAttribute ( "size", Integer.toString(this.properties.size ()) );
 
             for ( final Map.Entry<String, String> entry : this.properties.entrySet () )
             {
@@ -738,7 +739,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "provides" );
-            xsw.writeAttribute ( "size", "" + this.provides.size () );
+            xsw.writeAttribute ( "size", Integer.toString(this.provides.size ()) );
 
             for ( final Entry<String> entry : this.provides )
             {
@@ -754,7 +755,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "requires" );
-            xsw.writeAttribute ( "size", "" + this.requires.size () );
+            xsw.writeAttribute ( "size", Integer.toString(this.requires.size ()) );
 
             for ( final Entry<Requirement> entry : this.requires )
             {
@@ -800,7 +801,7 @@ public class InstallableUnit
         if ( !this.artifacts.isEmpty () )
         {
             xsw.writeStartElement ( "artifacts" );
-            xsw.writeAttribute ( "size", "" + this.artifacts.size () );
+            xsw.writeAttribute ( "size", Integer.toString(this.artifacts.size ()) );
 
             for ( final Artifact artifact : this.artifacts )
             {
@@ -834,7 +835,7 @@ public class InstallableUnit
                         xsw.writeAttribute ( "size", "1" );
 
                         xsw.writeStartElement ( "instructions" );
-                        xsw.writeAttribute ( "size", "" + tp.getInstructions ().size () );
+                        xsw.writeAttribute ( "size", Integer.toString(tp.getInstructions ().size ()) );
 
                         for ( final Map.Entry<String, String> entry : tp.getInstructions ().entrySet () )
                         {
@@ -853,7 +854,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "licenses" );
-            xsw.writeAttribute ( "size", "" + this.licenses.size () );
+            xsw.writeAttribute ( "size", Integer.toString(this.licenses.size ()) );
 
             for ( final License licenseEntry : this.licenses )
             {

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
@@ -599,7 +599,7 @@ public class InstallableUnit
 
     /**
      * Add property entry only of value is not null
-     *
+     * 
      * @param props
      *            properties
      * @param key
@@ -665,7 +665,7 @@ public class InstallableUnit
 
     /**
      * Write a list of units inside a {@code units} element
-     *
+     * 
      * @param xsw
      *            the stream to write to
      * @param ius
@@ -676,7 +676,7 @@ public class InstallableUnit
     public static void writeXml ( final XMLStreamWriter xsw, final List<InstallableUnit> ius ) throws XMLStreamException
     {
         xsw.writeStartElement ( "units" );
-        xsw.writeAttribute ( "size", Integer.toString(ius.size ()) );
+        xsw.writeAttribute ( "size", Integer.toString ( ius.size () ) );
         for ( final InstallableUnit iu : ius )
         {
             iu.writeXmlForUnit ( xsw );
@@ -686,7 +686,7 @@ public class InstallableUnit
 
     /**
      * Write a single unit inside a {@code units} element
-     *
+     * 
      * @param xsw
      *            the stream to write to
      * @throws XMLStreamException
@@ -699,7 +699,7 @@ public class InstallableUnit
 
     /**
      * Write the unit as XML fragment
-     *
+     * 
      * @param xsw
      *            the XMLStreamWriter to write to
      * @throws XMLStreamException
@@ -710,7 +710,7 @@ public class InstallableUnit
         xsw.writeStartElement ( "unit" );
         xsw.writeAttribute ( "id", this.id );
         xsw.writeAttribute ( "version", "" + this.version );
-        xsw.writeAttribute ( "singleton", Boolean.toString(this.singleton) );
+        xsw.writeAttribute ( "singleton", Boolean.toString ( this.singleton ) );
 
         {
             xsw.writeEmptyElement ( "update" );
@@ -721,7 +721,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "properties" );
-            xsw.writeAttribute ( "size", Integer.toString(this.properties.size ()) );
+            xsw.writeAttribute ( "size", Integer.toString ( this.properties.size () ) );
 
             for ( final Map.Entry<String, String> entry : this.properties.entrySet () )
             {
@@ -739,7 +739,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "provides" );
-            xsw.writeAttribute ( "size", Integer.toString(this.provides.size ()) );
+            xsw.writeAttribute ( "size", Integer.toString ( this.provides.size () ) );
 
             for ( final Entry<String> entry : this.provides )
             {
@@ -755,7 +755,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "requires" );
-            xsw.writeAttribute ( "size", Integer.toString(this.requires.size ()) );
+            xsw.writeAttribute ( "size", Integer.toString ( this.requires.size () ) );
 
             for ( final Entry<Requirement> entry : this.requires )
             {
@@ -801,7 +801,7 @@ public class InstallableUnit
         if ( !this.artifacts.isEmpty () )
         {
             xsw.writeStartElement ( "artifacts" );
-            xsw.writeAttribute ( "size", Integer.toString(this.artifacts.size ()) );
+            xsw.writeAttribute ( "size", Integer.toString ( this.artifacts.size () ) );
 
             for ( final Artifact artifact : this.artifacts )
             {
@@ -835,7 +835,7 @@ public class InstallableUnit
                         xsw.writeAttribute ( "size", "1" );
 
                         xsw.writeStartElement ( "instructions" );
-                        xsw.writeAttribute ( "size", Integer.toString(tp.getInstructions ().size ()) );
+                        xsw.writeAttribute ( "size", Integer.toString ( tp.getInstructions ().size () ) );
 
                         for ( final Map.Entry<String, String> entry : tp.getInstructions ().entrySet () )
                         {
@@ -854,7 +854,7 @@ public class InstallableUnit
 
         {
             xsw.writeStartElement ( "licenses" );
-            xsw.writeAttribute ( "size", Integer.toString(this.licenses.size ()) );
+            xsw.writeAttribute ( "size", Integer.toString ( this.licenses.size () ) );
 
             for ( final License licenseEntry : this.licenses )
             {

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/internal/Creator.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/internal/Creator.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.aspect.common.p2.internal;
 
@@ -77,7 +78,7 @@ public class Creator
                     size++;
                 }
 
-                xsw.writeAttribute ( "size", "" + size );
+                xsw.writeAttribute ( "size", Integer.toString(size) );
 
                 writeProperty ( xsw, "download.size", "" + artifact.getSize () ); // #1
                 writeProperty ( xsw, "artifact.size", "" + artifact.getSize () ); // #2

--- a/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/FeatureGenerator.java
+++ b/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/FeatureGenerator.java
@@ -239,7 +239,7 @@ public class FeatureGenerator implements ArtifactGenerator
 
         p.setAttribute ( "id", id );
         p.setAttribute ( "version", version );
-        p.setAttribute ( "unpack", Boolean.toString(unpack) );
+        p.setAttribute ( "unpack", Boolean.toString ( unpack ) );
     }
 
     @Override

--- a/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/FeatureGenerator.java
+++ b/bundles/org.eclipse.packagedrone.repo.generator.p2/src/org/eclipse/packagedrone/repo/generator/p2/FeatureGenerator.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.generator.p2;
 
@@ -238,7 +239,7 @@ public class FeatureGenerator implements ArtifactGenerator
 
         p.setAttribute ( "id", id );
         p.setAttribute ( "version", version );
-        p.setAttribute ( "unpack", "" + unpack );
+        p.setAttribute ( "unpack", Boolean.toString(unpack) );
     }
 
     @Override

--- a/bundles/org.eclipse.packagedrone.repo.xml/src/org/eclipse/packagedrone/repo/xml/XmlHelper.java
+++ b/bundles/org.eclipse.packagedrone.repo.xml/src/org/eclipse/packagedrone/repo/xml/XmlHelper.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.xml;
 
@@ -394,7 +395,7 @@ public class XmlHelper
 
         if ( len > 0 )
         {
-            element.setAttribute ( "size", "" + len );
+            element.setAttribute ( "size", Integer.toString(len) );
         }
         else
         {

--- a/bundles/org.eclipse.packagedrone.repo.xml/src/org/eclipse/packagedrone/repo/xml/XmlHelper.java
+++ b/bundles/org.eclipse.packagedrone.repo.xml/src/org/eclipse/packagedrone/repo/xml/XmlHelper.java
@@ -161,8 +161,9 @@ public class XmlHelper
     }
 
     /**
-     * @deprecated Instead the class {@link
-     *             org.eclipse.packagedrone.utils.xml.XmlToolsFactory} should be
+     * @deprecated Instead the class
+     *             {@link org.eclipse.packagedrone.utils.xml.XmlToolsFactory}
+     *             should be
      *             used.
      */
     @Deprecated
@@ -337,7 +338,7 @@ public class XmlHelper
 
     /**
      * Create a new element and add it as the last child
-     *
+     * 
      * @param parent
      *            the parent of the new element
      * @param name
@@ -375,7 +376,7 @@ public class XmlHelper
 
     /**
      * Create a new element and add it as the first child
-     *
+     * 
      * @param parent
      *            the parent to which to add the element
      * @param name
@@ -395,7 +396,7 @@ public class XmlHelper
 
         if ( len > 0 )
         {
-            element.setAttribute ( "size", Integer.toString(len) );
+            element.setAttribute ( "size", Integer.toString ( len ) );
         }
         else
         {
@@ -407,18 +408,18 @@ public class XmlHelper
      * Get the text value of the first element with the matching name
      * <p>
      * Assuming you have an XML file:
-     *
+     * 
      * <pre>
      * &lt;parent&gt;
      * &nbsp;&nbsp;&lt;foo&gt;bar&lt;/foo&gt;
      * &nbsp;&nbsp;&lt;hello&gt;world&lt;/hello&gt;
      * &lt;/parent&gt;
      * </pre>
-     *
+     * 
      * Calling {@link #getText(Element, String)} with "parent" as element and
      * "hello" as name, it would return "world".
      * </p>
-     *
+     * 
      * @param ele
      *            the element to check
      * @param name

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
@@ -173,7 +173,7 @@ public class DebianPackageWriter implements AutoCloseable, BinaryPackageBuilder
         directory = cleanupPath ( directory );
         if ( !directory.endsWith ( "/" ) )
         {
-            directory += Character.toString('/');
+            directory += Character.toString ( '/' );
         }
         checkCreateParents ( directory );
         internalAddDirectory ( directory, entryInformation );
@@ -308,7 +308,7 @@ public class DebianPackageWriter implements AutoCloseable, BinaryPackageBuilder
 
     protected ContentProvider createControlContent () throws IOException
     {
-        this.packageControlFile.set ( BinaryPackageControlFile.Fields.INSTALLED_SIZE, Long.toString(this.installedSize) );
+        this.packageControlFile.set ( BinaryPackageControlFile.Fields.INSTALLED_SIZE, Long.toString ( this.installedSize ) );
 
         final StringWriter sw = new StringWriter ();
         final ControlFileWriter writer = new ControlFileWriter ( sw, BinaryPackageControlFile.FORMATTERS );

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2131
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.deb.build;
 
@@ -172,7 +173,7 @@ public class DebianPackageWriter implements AutoCloseable, BinaryPackageBuilder
         directory = cleanupPath ( directory );
         if ( !directory.endsWith ( "/" ) )
         {
-            directory += '/';
+            directory += Character.toString('/');
         }
         checkCreateParents ( directory );
         internalAddDirectory ( directory, entryInformation );
@@ -307,7 +308,7 @@ public class DebianPackageWriter implements AutoCloseable, BinaryPackageBuilder
 
     protected ContentProvider createControlContent () throws IOException
     {
-        this.packageControlFile.set ( BinaryPackageControlFile.Fields.INSTALLED_SIZE, "" + this.installedSize );
+        this.packageControlFile.set ( BinaryPackageControlFile.Fields.INSTALLED_SIZE, Long.toString(this.installedSize) );
 
         final StringWriter sw = new StringWriter ();
         final ControlFileWriter writer = new ControlFileWriter ( sw, BinaryPackageControlFile.FORMATTERS );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for String conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat