### PR TITLE
squid:S2162 - equals methods should be symmetric and work for subclasses

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/MavenInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/MavenInformation.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.maven;
 
@@ -214,7 +215,7 @@ public class MavenInformation
         {
             return false;
         }
-        if ( ! ( obj instanceof MavenInformation ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/upload/Coordinates.java
+++ b/bundles/org.eclipse.packagedrone.repo.adapter.maven/src/org/eclipse/packagedrone/repo/adapter/maven/upload/Coordinates.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.adapter.maven.upload;
 
@@ -109,7 +110,7 @@ public class Coordinates
         {
             return false;
         }
-        if ( ! ( obj instanceof Coordinates ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.channel.web/src/org/eclipse/packagedrone/repo/channel/web/channel/AspectInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.channel.web/src/org/eclipse/packagedrone/repo/channel/web/channel/AspectInformation.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 
 package org.eclipse.packagedrone.repo.channel.web.channel;
@@ -232,7 +233,7 @@ public class AspectInformation
         {
             return false;
         }
-        if ( ! ( obj instanceof AspectInformation ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }
@@ -313,7 +314,7 @@ public class AspectInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof Group ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }

--- a/bundles/org.eclipse.packagedrone.repo.cleanup/src/org/eclipse/packagedrone/repo/cleanup/Field.java
+++ b/bundles/org.eclipse.packagedrone.repo.cleanup/src/org/eclipse/packagedrone/repo/cleanup/Field.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.cleanup;
 
@@ -74,7 +75,7 @@ public class Field
         {
             return false;
         }
-        if ( ! ( obj instanceof Field ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.cleanup/src/org/eclipse/packagedrone/repo/cleanup/ResultKey.java
+++ b/bundles/org.eclipse.packagedrone.repo.cleanup/src/org/eclipse/packagedrone/repo/cleanup/ResultKey.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.cleanup;
 
@@ -95,7 +96,7 @@ public class ResultKey implements Comparable<ResultKey>
         {
             return false;
         }
-        if ( ! ( obj instanceof ResultKey ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.generator/src/org/eclipse/packagedrone/repo/generator/GeneratorInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.generator/src/org/eclipse/packagedrone/repo/generator/GeneratorInformation.java
@@ -60,7 +60,7 @@ public class GeneratorInformation implements Comparable<GeneratorInformation>
         {
             return false;
         }
-        if ( ! ( obj instanceof GeneratorInformation ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.importer.aether/src/org/eclipse/packagedrone/repo/importer/aether/MavenCoordinates.java
+++ b/bundles/org.eclipse.packagedrone.repo.importer.aether/src/org/eclipse/packagedrone/repo/importer/aether/MavenCoordinates.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.importer.aether;
 
@@ -236,7 +237,7 @@ public class MavenCoordinates implements Comparable<MavenCoordinates>
         {
             return false;
         }
-        if ( ! ( obj instanceof MavenCoordinates ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.utils.osgi.bundle;
 
@@ -79,7 +80,7 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof PackageImport ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }
@@ -156,7 +157,7 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof PackageExport ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }
@@ -241,7 +242,7 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof BundleRequirement ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/feature/FeatureInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/feature/FeatureInformation.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.utils.osgi.feature;
 
@@ -275,7 +276,7 @@ public class FeatureInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof PluginInclude ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }
@@ -400,7 +401,7 @@ public class FeatureInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( ! ( obj instanceof FeatureInclude ) )
+            if ( this.getClass() != obj.getClass() )
             {
                 return false;
             }

--- a/bundles/org.eclipse.packagedrone.repo/src/org/eclipse/packagedrone/repo/MetaKey.java
+++ b/bundles/org.eclipse.packagedrone.repo/src/org/eclipse/packagedrone/repo/MetaKey.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo;
 
@@ -82,7 +83,7 @@ public class MetaKey implements Comparable<MetaKey>, Serializable
         {
             return false;
         }
-        if ( ! ( obj instanceof MetaKey ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.repo/src/org/eclipse/packagedrone/repo/Version.java
+++ b/bundles/org.eclipse.packagedrone.repo/src/org/eclipse/packagedrone/repo/Version.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.repo;
 
@@ -88,7 +89,7 @@ public class Version implements Comparable<Version>
         {
             return false;
         }
-        if ( ! ( obj instanceof Version ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.sec.service.apm/src/org/eclipse/packagedrone/sec/service/apm/model/UserEntity.java
+++ b/bundles/org.eclipse.packagedrone.sec.service.apm/src/org/eclipse/packagedrone/sec/service/apm/model/UserEntity.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.sec.service.apm.model;
 
@@ -226,7 +227,7 @@ public class UserEntity
         {
             return false;
         }
-        if ( ! ( obj instanceof UserEntity ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }

--- a/bundles/org.eclipse.packagedrone.sec/src/org/eclipse/packagedrone/sec/UserInformation.java
+++ b/bundles/org.eclipse.packagedrone.sec/src/org/eclipse/packagedrone/sec/UserInformation.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S2162
  *******************************************************************************/
 package org.eclipse.packagedrone.sec;
 
@@ -83,7 +84,7 @@ public class UserInformation implements Comparable<UserInformation>
         {
             return false;
         }
-        if ( ! ( obj instanceof UserInformation ) )
+        if ( this.getClass() != obj.getClass() )
         {
             return false;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat