### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.manage.system/src/org/eclipse/packagedrone/repo/manage/system/internal/SystemServiceImpl.java
+++ b/bundles/org.eclipse.packagedrone.repo.manage.system/src/org/eclipse/packagedrone/repo/manage/system/internal/SystemServiceImpl.java
@@ -7,13 +7,16 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S1943 
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.manage.system.internal;
 
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.packagedrone.repo.manage.system.SystemService;
 
@@ -90,8 +93,10 @@ public class SystemServiceImpl implements SystemService
 
         if ( hostname == null )
         {
-            try ( Reader reader = new FileReader ( "/etc/hostname" ) )
+
+            try ( FileInputStream fileInputStream = new FileInputStream ( "/etc/hostname" ) )
             {
+                InputStreamReader reader = new InputStreamReader ( fileInputStream, StandardCharsets.UTF_8 );
                 hostname = CharStreams.toString ( reader ).trim ();
             }
             catch ( final Exception e )

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/ControlFileParser.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/ControlFileParser.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S1943
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.deb;
 
@@ -50,7 +51,7 @@ public final class ControlFileParser
 
     public static LinkedHashMap<String, String> parse ( final InputStream stream ) throws IOException, ParserException
     {
-        return parse ( new InputStreamReader ( stream ) );
+        return parse ( new InputStreamReader ( stream, StandardCharsets.UTF_8 ) );
     }
 
     public static LinkedHashMap<String, String> parse ( final Reader inputReader ) throws IOException, ParserException

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/DebianPackageWriter.java
@@ -7,7 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
- *     M-Ezzat - code cleanup - squid:S2131
+ *     M-Ezzat - code cleanup - squid:S2131, squid:S1943
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.deb.build;
 
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,7 +46,7 @@ public class DebianPackageWriter implements AutoCloseable, BinaryPackageBuilder
 
     private final ArArchiveOutputStream ar;
 
-    private final byte[] binaryHeader = "2.0\n".getBytes ();
+    private final byte[] binaryHeader = "2.0\n".getBytes ( StandardCharsets.UTF_8 );
 
     private final File dataTemp;
 

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/TextFileContentProvider.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/TextFileContentProvider.java
@@ -7,15 +7,17 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     M-Ezzat - code cleanup - squid:S1943
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.deb.build;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
@@ -26,8 +28,9 @@ public class TextFileContentProvider implements ContentProvider
 
     public TextFileContentProvider ( final File file ) throws FileNotFoundException, IOException
     {
-        try ( FileReader reader = new FileReader ( file ) )
+        try ( FileInputStream fileInputStream = new FileInputStream ( file ) )
         {
+            InputStreamReader reader = new InputStreamReader ( fileInputStream, StandardCharsets.UTF_8 );
             if ( file != null )
             {
                 String data = IOUtils.toString ( reader );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
