### PR TITLE
Added "Project Import" as predecessor to "Launch Task".

### DIFF
--- a/setups/org.eclipse.packagedrone.oomph/PackageDrone.setup
+++ b/setups/org.eclipse.packagedrone.oomph/PackageDrone.setup
@@ -431,6 +431,7 @@
   </setupTask>
   <setupTask
       xsi:type="launching:LaunchTask"
+      predecessor="//@setupTasks.4"
       launcher="runtime/runtime build.ant.launch">
     <description>Launch the build script which creates the target platform bundle directory</description>
   </setupTask>


### PR DESCRIPTION
Otherwise ANT script cannot be found and the complete setup fail when creating a
fresh workspace.