### PR TITLE
added Supplier<Instant> to add... methods to allow reproducible builds

### DIFF
--- a/bundles/org.eclipse.packagedrone.utils.deb.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.packagedrone.utils.deb.tests/META-INF/MANIFEST.MF
@@ -3,10 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for 'org.eclipse.packagedrone.utils.deb'
 Bundle-SymbolicName: org.eclipse.packagedrone.utils.deb.tests
 Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: Jens Reimann
+Bundle-Vendor: Eclipse Package Drone
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit
-Import-Package: com.google.common.io;version="18.0.0",
+Import-Package: com.google.common.hash;version="18.0.0",
+ com.google.common.io;version="18.0.0",
  org.eclipse.packagedrone.utils.deb,
  org.eclipse.packagedrone.utils.deb.build;version="1.0.0",
  org.eclipse.packagedrone.utils.deb.control;version="1.0.0"

--- a/bundles/org.eclipse.packagedrone.utils.deb.tests/src/org/eclipse/packagedrone/utils/deb/tests/BinaryPackageTest.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb.tests/src/org/eclipse/packagedrone/utils/deb/tests/BinaryPackageTest.java
@@ -10,9 +10,16 @@
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.deb.tests;
 
+import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.function.Supplier;
 
 import org.eclipse.packagedrone.utils.deb.build.DebianPackageWriter;
 import org.eclipse.packagedrone.utils.deb.build.EntryInformation;
@@ -20,13 +27,46 @@ import org.eclipse.packagedrone.utils.deb.control.BinaryPackageControlFile;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.common.hash.Hashing;
+
 public class BinaryPackageTest
 {
     @Test
-    public void test1 () throws IOException
+    public void test1 () throws IOException, InterruptedException
     {
-        final File file = File.createTempFile ( "test-", ".deb" );
+        final File file1 = File.createTempFile ( "test-1-", ".deb" );
+        final File file2 = File.createTempFile ( "test-2-", ".deb" );
 
+        final long startOfYear = LocalDate.now ().with ( firstDayOfYear () ).toEpochDay () * 24 * 60 * 60 * 1000; // 2015-11-23
+        final Supplier<Instant> timestampProvider = new Supplier<Instant> () {
+            @Override
+            public Instant get ()
+            {
+                return Instant.ofEpochMilli ( startOfYear );
+            }
+        };
+
+        createDebFile ( file1, timestampProvider );
+        System.out.println ( "File: " + file1 );
+        Assert.assertTrue ( "File exists", file1.exists () );
+
+        Thread.sleep ( 10 );
+
+        createDebFile ( file2, timestampProvider );
+        System.out.println ( "File: " + file2 );
+        Assert.assertTrue ( "File exists", file2.exists () );
+
+        final byte[] b1 = Files.readAllBytes ( file1.toPath () );
+        final String h1 = Hashing.md5 ().hashBytes ( b1 ).toString ();
+        final byte[] b2 = Files.readAllBytes ( file2.toPath () );
+        final String h2 = Hashing.md5 ().hashBytes ( b2 ).toString ();
+        System.out.println ( h1 );
+        System.out.println ( h2 );
+        Assert.assertEquals ( h1, h2 );
+    }
+
+    private void createDebFile ( final File file1, final Supplier<Instant> timestampProvider ) throws IOException, FileNotFoundException
+    {
         final BinaryPackageControlFile packageFile = new BinaryPackageControlFile ();
         packageFile.setPackage ( "test" );
         packageFile.setVersion ( "0.0.1" );
@@ -34,12 +74,10 @@ public class BinaryPackageTest
         packageFile.setMaintainer ( "Jens Reimann <ctron@dentrassi.de>" );
         packageFile.setDescription ( "Test package\nThis is just a test package\n\nNothing to worry about!" );
 
-        try ( DebianPackageWriter deb = new DebianPackageWriter ( new FileOutputStream ( file ), packageFile ) )
+        try ( DebianPackageWriter deb = new DebianPackageWriter ( new FileOutputStream ( file1 ), packageFile ) )
         {
-            deb.addFile ( "Hello World\n".getBytes (), "/usr/share/foo-test/foo.txt", null );
-            deb.addFile ( "Hello World\n".getBytes (), "/etc/foo.txt", EntryInformation.DEFAULT_FILE_CONF );
+            deb.addFile ( "Hello World\n".getBytes (), "/usr/share/foo-test/foo.txt", null, timestampProvider );
+            deb.addFile ( "Hello World\n".getBytes (), "/etc/foo.txt", EntryInformation.DEFAULT_FILE_CONF, timestampProvider );
         }
-        System.out.println ( "File: " + file );
-        Assert.assertTrue ( "File exists", file.exists () );
     }
 }

--- a/bundles/org.eclipse.packagedrone.utils.deb/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.packagedrone.utils.deb/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Debian Tools
+Bundle-Name: Java DEB Library
 Bundle-SymbolicName: org.eclipse.packagedrone.utils.deb
 Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: Jens Reimann
+Bundle-Vendor: Eclipse Package Drone
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.commons.compress.archivers;version="1.9.0",
  org.apache.commons.compress.archivers.ar;version="1.9.0",

--- a/bundles/org.eclipse.packagedrone.utils.deb/secondary.pom
+++ b/bundles/org.eclipse.packagedrone.utils.deb/secondary.pom
@@ -7,7 +7,7 @@
 		<groupId>org.eclipse.packagedrone</groupId>
 		<artifactId>secondary-parent</artifactId>
 		<version>0.14.0-SNAPSHOT</version>
-		<relativePath>../../secondary</relativePath>	
+		<relativePath>../../secondary</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.packagedrone.utils.deb</artifactId>
@@ -27,6 +27,11 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.packagedrone</groupId>
+			<artifactId>org.eclipse.packagedrone.utils</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/BinaryPackageBuilder.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/BinaryPackageBuilder.java
@@ -11,9 +11,11 @@
 package org.eclipse.packagedrone.utils.deb.build;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.function.Supplier;
 
 /**
- * An interface for binary installation package builders <br/>
+ * An interface for binary installation package builders<br>
  * <p>
  * Target path names are relative to the root of the system. Absolute paths will
  * stay absolute and relative ones get converted to absolute using root. So
@@ -35,7 +37,26 @@ public interface BinaryPackageBuilder
      * @throws IOException
      *             if the file cannot be written to the package
      */
-    public void addFile ( ContentProvider contentProvider, String fileName, EntryInformation entryInformation ) throws IOException;
+    public default void addFile ( final ContentProvider contentProvider, final String fileName, final EntryInformation entryInformation ) throws IOException
+    {
+        addFile ( contentProvider, fileName, entryInformation, null );
+    }
+
+    /**
+     * Add a file to the binary package
+     *
+     * @param contentProvider
+     *            the content provider
+     * @param fileName
+     *            the name of the target file
+     * @param entryInformation
+     *            additional entry information
+     * @param timestampSupplier
+     *            use given time stamp for modification
+     * @throws IOException
+     *             if the file cannot be written to the package
+     */
+    public void addFile ( ContentProvider contentProvider, String fileName, EntryInformation entryInformation, Supplier<Instant> timestampSupplier ) throws IOException;
 
     /**
      * Add a directory to the binary package
@@ -47,6 +68,22 @@ public interface BinaryPackageBuilder
      * @throws IOException
      *             if the directory information cannot be written to the package
      */
-    public void addDirectory ( String directory, EntryInformation entryInformation ) throws IOException;
+    public default void addDirectory ( final String directory, final EntryInformation entryInformation ) throws IOException
+    {
+        addDirectory ( directory, entryInformation, null );
+    }
 
+    /**
+     * Add a directory to the binary package
+     *
+     * @param directory
+     *            the name of the target directory
+     * @param entryInformation
+     *            additional entry information
+     * @param timestampSupplier
+     *            use given time stamp for modification
+     * @throws IOException
+     *             if the directory information cannot be written to the package
+     */
+    public void addDirectory ( String directory, EntryInformation entryInformation, Supplier<Instant> timestampSupplier ) throws IOException;
 }

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/BinaryPackageBuilder.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/BinaryPackageBuilder.java
@@ -12,6 +12,7 @@ package org.eclipse.packagedrone.utils.deb.build;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -39,7 +40,7 @@ public interface BinaryPackageBuilder
      */
     public default void addFile ( final ContentProvider contentProvider, final String fileName, final EntryInformation entryInformation ) throws IOException
     {
-        addFile ( contentProvider, fileName, entryInformation, null );
+        addFile ( contentProvider, fileName, entryInformation, Optional.empty () );
     }
 
     /**
@@ -56,7 +57,7 @@ public interface BinaryPackageBuilder
      * @throws IOException
      *             if the file cannot be written to the package
      */
-    public void addFile ( ContentProvider contentProvider, String fileName, EntryInformation entryInformation, Supplier<Instant> timestampSupplier ) throws IOException;
+    public void addFile ( ContentProvider contentProvider, String fileName, EntryInformation entryInformation, Optional<Supplier<Instant>> timestampSupplier ) throws IOException;
 
     /**
      * Add a directory to the binary package
@@ -70,7 +71,7 @@ public interface BinaryPackageBuilder
      */
     public default void addDirectory ( final String directory, final EntryInformation entryInformation ) throws IOException
     {
-        addDirectory ( directory, entryInformation, null );
+        addDirectory ( directory, entryInformation, Optional.empty () );
     }
 
     /**
@@ -85,5 +86,5 @@ public interface BinaryPackageBuilder
      * @throws IOException
      *             if the directory information cannot be written to the package
      */
-    public void addDirectory ( String directory, EntryInformation entryInformation, Supplier<Instant> timestampSupplier ) throws IOException;
+    public void addDirectory ( String directory, EntryInformation entryInformation, Optional<Supplier<Instant>> timestampSupplier ) throws IOException;
 }

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/ContentProvider.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/build/ContentProvider.java
@@ -39,7 +39,7 @@ public interface ContentProvider
     public long getSize ();
 
     /**
-     * Create a new input stream <br/>
+     * Create a new input stream <br>
      * <em>Note:</em> The caller must close the stream
      *
      * @return a new input stream

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/control/GenericControlFile.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/control/GenericControlFile.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A generic control file <br/>
+ * A generic control file <br>
  * This type can be used to implement other control files are directly.
  */
 public class GenericControlFile

--- a/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/internal/ChecksumInputStream.java
+++ b/bundles/org.eclipse.packagedrone.utils.deb/src/org/eclipse/packagedrone/utils/deb/internal/ChecksumInputStream.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 /**
  * A filter input stream which create multiple message digests while reading
- * <br/>
+ * <br>
  * Only the bytes actually read are processed.
  */
 public class ChecksumInputStream extends FilterInputStream


### PR DESCRIPTION
Every add... method has now optionally a Supplier<Instant> as a
parameter, to allow override of the default timestamp (usually the
current time). Also fixed vendor entry, some javadoc issues, a maven
build issue and added test for reproducible build.

Signed-off-by: Juergen Rose <juergen.rose@ibh-systems.com>