### PR TITLE
Replace configuration with RPM FileFlags.

### DIFF
--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/FileFlags.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/FileFlags.java
@@ -7,12 +7,25 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     SMX Ltd. - support for additional RPM file flags
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.rpm;
 
+import java.util.EnumSet;
+
 public enum FileFlags
 {
-    CONFIGURATION ( 1 );
+    CONFIGURATION ( 1 <<  0 ), /*!< from %%config */
+    DOC ( 1 <<  1 ), /*!< from %%doc */
+    ICON ( 1 <<  2 ), /*!< from %%donotuse. */
+    MISSINGOK ( 1 <<  3 ), /*!< from %%config(missingok) */
+    NOREPLACE ( 1 <<  4 ), /*!< from %%config(noreplace) */
+    GHOST ( 1 <<  6 ), /*!< from %%ghost */
+    LICENSE ( 1 <<  7 ), /*!< from %%license */
+    README ( 1 <<  8 ), /*!< from %%readme */
+    /* bits 9-10 unused */
+    PUBKEY ( 1 << 11 ), /*!< from %%pubkey */
+    ARTIFACT ( 1 << 12 );	/*!< from %%artifact */
 
     private int value;
 
@@ -25,4 +38,21 @@ public enum FileFlags
     {
         return this.value;
     }
+
+    public static EnumSet<FileFlags> decode( int flagValue )
+    {
+        EnumSet<FileFlags> fileFlags = EnumSet.noneOf( FileFlags.class );
+        if ( flagValue != 0 )
+        {
+            for ( FileFlags fileFlag : FileFlags.values() )
+            {
+                if ( ( fileFlag.getValue() & flagValue ) == fileFlag.getValue() )
+                {
+                    fileFlags.add(fileFlag);
+                }
+            }
+        }
+        return fileFlags;
+    }
+
 }

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/FileInformation.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/FileInformation.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.rpm.build;
 
+import org.eclipse.packagedrone.utils.rpm.FileFlags;
+
+import java.util.EnumSet;
 import java.time.Instant;
 
 public class FileInformation
@@ -20,7 +23,7 @@ public class FileInformation
 
     private String group = BuilderContext.DEFAULT_GROUP;
 
-    private boolean configuration = false;
+    private EnumSet<FileFlags> fileFlags = EnumSet.noneOf(FileFlags.class);
 
     private short mode = 0644;
 
@@ -34,14 +37,33 @@ public class FileInformation
         return this.timestamp;
     }
 
+    @Deprecated
     public void setConfiguration ( final boolean configuration )
     {
-        this.configuration = configuration;
+        if ( configuration == true)
+        {
+            this.fileFlags.add(FileFlags.CONFIGURATION);
+        }
+        else
+        {
+            this.fileFlags.remove(FileFlags.CONFIGURATION);
+        }
     }
 
+    @Deprecated
     public boolean isConfiguration ()
     {
-        return this.configuration;
+        return this.fileFlags.contains(FileFlags.CONFIGURATION);
+    }
+
+    public void setFileFlags ( final EnumSet<FileFlags> fileFlags )
+    {
+        this.fileFlags = fileFlags;
+    }
+
+    public EnumSet<FileFlags> getFileFlags()
+    {
+        return this.fileFlags;
     }
 
     public void setUser ( final String user )
@@ -77,6 +99,6 @@ public class FileInformation
     @Override
     public String toString ()
     {
-        return String.format ( "[FileInformation - user: %s, group: %s, mode: 0%04o, cfg: %s]", this.user, this.group, this.mode, this.configuration );
+        return String.format ( "[FileInformation - user: %s, group: %s, mode: 0%04o, flags: %s]", this.user, this.group, this.mode, this.fileFlags );
     }
 }

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -450,9 +451,12 @@ public class RpmBuilder implements AutoCloseable
         protected void customizeFile ( final FileEntry entry, final FileInformation information )
         {
             customizeCommon ( entry, information );
-            if ( information.isConfiguration () )
+            if ( !information.getFileFlags().isEmpty() )
             {
-                entry.setFlags ( entry.getFlags () | FileFlags.CONFIGURATION.getValue () );
+                for ( FileFlags fileFlag : information.getFileFlags() )
+                {
+                    entry.setFlags ( entry.getFlags () | fileFlag.getValue () );
+                }
             }
         }
 


### PR DESCRIPTION
A while ago we had a need/desire to configure our config files with %noreplace, but this wasn't supported or easily exposed via the current PackageDrone library.

This patch adds the full set of RPMFILE_* file flags defined by the current RPM project, and exposes setting those FileFlags via the `FileInformation` class. The existing `CONFIGURATION` and `setConfiguration` / `isConfiguration` code has been left in, but deprecated for now.

Initially I was going to base this PR on the `master` branch, but it seems that doesn't match the 0.14.1 release that's available in Maven Central, so this PR is based off the `0.14.x-release` branch.

CLA has been signed.
