### PR TITLE
Extract all entries from the Manifest

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Service-Component: OSGI-INF/hash.xml,
  OSGI-INF/tycho-cleaner.xml,
  OSGI-INF/eclipseSourceBundle.xml,
  OSGI-INF/groupOther.xml,
- OSGI-INF/groupOsgi.xml
+ OSGI-INF/groupOsgi.xml,
+ OSGI-INF/manifest.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.packagedrone.repo.aspect.common.osgi;version="1.0.0";
   uses:="org.eclipse.packagedrone.repo.aspect,

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/OSGI-INF/manifest.properties
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/OSGI-INF/manifest.properties
@@ -1,0 +1,4 @@
+drone.aspect.id=manifest
+service.description=Extract manifest information as metadata
+drone.aspect.name=Manifest
+drone.aspect.version=1.0.0

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/OSGI-INF/manifest.xml
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/OSGI-INF/manifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.packagedrone.repo.aspect.common">
+   <implementation class="org.eclipse.packagedrone.repo.aspect.common.manifest.ManifestAspectFactory"/>
+   <service>
+      <provide interface="org.eclipse.packagedrone.repo.aspect.ChannelAspectFactory"/>
+   </service>
+   <properties entry="OSGI-INF/manifest.properties"/>
+</scr:component>

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/manifest/ManifestAspectFactory.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/manifest/ManifestAspectFactory.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Gemtec GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Peter Jeschke/Gemtec GmbH - initial implementation
+ *******************************************************************************/
+package org.eclipse.packagedrone.repo.aspect.common.manifest;
+
+import org.eclipse.packagedrone.repo.aspect.ChannelAspect;
+import org.eclipse.packagedrone.repo.aspect.ChannelAspectFactory;
+import org.eclipse.packagedrone.repo.aspect.extract.Extractor;
+
+/**
+ * Provides manifest information as metadata.
+ *
+ * @author Peter Jeschke
+ */
+public class ManifestAspectFactory implements ChannelAspectFactory
+{
+    private static final String ID = "manifest";
+
+    @Override
+    public ChannelAspect createAspect ()
+    {
+        return new ChannelAspect () {
+
+            @Override
+            public Extractor getExtractor ()
+            {
+                return new ManifestMetadataExtractor ();
+            }
+
+            @Override
+            public String getId ()
+            {
+                return ID;
+            }
+        };
+    }
+
+}

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/manifest/ManifestMetadataExtractor.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/manifest/ManifestMetadataExtractor.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Gemtec GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Peter Jeschke/Gemtec GmbH - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.packagedrone.repo.aspect.common.manifest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import org.eclipse.packagedrone.repo.aspect.extract.Extractor;
+
+/**
+ * Extracts all manifest entries as metadata.
+ *
+ * @author Peter Jeschke
+ */
+final class ManifestMetadataExtractor implements Extractor
+{
+
+    @Override
+    public void extractMetaData ( final Context context, final Map<String, String> metadata ) throws Exception
+    {
+        final Manifest manifest = extractManifest ( context );
+        if ( manifest == null )
+        {
+            return;
+        }
+        storeManifestData ( manifest, metadata );
+    }
+
+    private Manifest extractManifest ( final Context context ) throws IOException
+    {
+        try ( ZipFile zipFile = new ZipFile ( context.getPath ().toFile () ) )
+        {
+            final ZipEntry m = zipFile.getEntry ( JarFile.MANIFEST_NAME );
+            if ( m == null )
+            {
+                return null;
+            }
+            try ( InputStream is = zipFile.getInputStream ( m ) )
+            {
+                return new Manifest ( is );
+            }
+        }
+        catch ( @SuppressWarnings ( "unused" ) final ZipException ex )
+        {
+            // probably not a zip file
+            return null;
+        }
+    }
+
+    private void storeManifestData ( final Manifest manifest, final Map<String, String> metadata )
+    {
+        for ( final Entry<Object, Object> entry : manifest.getMainAttributes ().entrySet () )
+        {
+            metadata.put ( ( (Attributes.Name)entry.getKey () ).toString (), (String)entry.getValue () );
+        }
+    }
+}

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/osgi/OsgiExtractor.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/osgi/OsgiExtractor.java
@@ -15,7 +15,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -126,8 +125,6 @@ public class OsgiExtractor implements Extractor
                 manifest = new Manifest ( is );
             }
 
-            storeManifestData ( manifest, metadata );
-
             try
             {
                 bi = new BundleInformationParser ( zipFile, manifest ).parse ();
@@ -176,14 +173,6 @@ public class OsgiExtractor implements Extractor
         // store bundle information
         metadata.put ( KEY_NAME_BUNDLE_INFORMATION, bi.toJson () );
 
-    }
-
-    private void storeManifestData ( final Manifest manifest, final Map<String, String> metadata )
-    {
-        for ( final Entry<Object, Object> entry : manifest.getMainAttributes ().entrySet () )
-        {
-            metadata.put ( ( (Attributes.Name)entry.getKey () ).toString (), (String)entry.getValue () );
-        }
     }
 
     private boolean validateBundle ( final Context context, final BundleInformation bi )

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/osgi/OsgiExtractor.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/osgi/OsgiExtractor.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -125,6 +126,8 @@ public class OsgiExtractor implements Extractor
                 manifest = new Manifest ( is );
             }
 
+            storeManifestData ( manifest, metadata );
+
             try
             {
                 bi = new BundleInformationParser ( zipFile, manifest ).parse ();
@@ -173,6 +176,14 @@ public class OsgiExtractor implements Extractor
         // store bundle information
         metadata.put ( KEY_NAME_BUNDLE_INFORMATION, bi.toJson () );
 
+    }
+
+    private void storeManifestData ( final Manifest manifest, final Map<String, String> metadata )
+    {
+        for ( final Entry<Object, Object> entry : manifest.getMainAttributes ().entrySet () )
+        {
+            metadata.put ( ( (Attributes.Name)entry.getKey () ).toString (), (String)entry.getValue () );
+        }
     }
 
     private boolean validateBundle ( final Context context, final BundleInformation bi )


### PR DESCRIPTION
This addition adds all keys from the Manifest file as metadata.

The use case for this is to have (for example) more filter options available for the cleaner aspect. We have multiple custom entries in our manifests that we want to use as parameter for the cleaner, but the fullManifest entry doesn't cut it for us because we also have entries that might change randomly. 

This can be improved by making this independent from the OSGI-aspect because Manifests exist in non-osgi JARs, too. But I decided to just put it where the fullManifest metadata is read.
