### PR TITLE
Creator writes files in UTF-8

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/internal/Creator.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/internal/Creator.java
@@ -132,7 +132,7 @@ public class Creator
         this.context.create ( makeName ( art, "-p2metadata.xml" ), out -> {
             try
             {
-                final XMLStreamWriter xsw = this.factoryProvider.get ().createXMLStreamWriter ( out );
+                final XMLStreamWriter xsw = this.factoryProvider.get ().createXMLStreamWriter ( out, "UTF-8" );
                 InstallableUnit.writeXml ( xsw, ius );
                 xsw.close ();
             }


### PR DESCRIPTION
Because ExtractorImpl in line 55 reads XML file in UTF-8 format Creator
has to write them in UTF-8. This is important for Windows installations
when frature files contain non standard characters in descriptions

Signed-off-by: Veselin Markov <veselin_m@yahoo.com>