### PR TITLE
Customize filename

### DIFF
--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
@@ -10,6 +10,7 @@
  *     Red Hat Inc - fix an issue with no-files RPMs
  *          - allowing the target name for the customizer
  *          - allow lead arch/os override
+ *     Yariv Amar - customize RPM final file name
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.rpm.build;
 
@@ -509,6 +510,38 @@ public class RpmBuilder implements AutoCloseable
 
     private OperatingSystem leadOverrideOperatingSystem;
 
+    private RpmFileNameProvider rpmFileNameProvider = LEGACY_FILENAME_PROVIDER;
+
+    /**
+     * this provider is the legacy file name format, using "-" before the "arch.rpm"
+     * it is here, and set as the default for backwards compatibility
+     */
+    public static final RpmFileNameProvider LEGACY_FILENAME_PROVIDER = new RpmFileNameProvider () {
+
+        @Override
+        public String getRpmFileName ( final RpmBuilder rpmBuilder )
+        {
+            final StringBuilder sb = new StringBuilder ( RpmLead.toLeadName ( rpmBuilder.getName (), rpmBuilder.getVersion () ) );
+            sb.append ( '-' ).append ( rpmBuilder.getArchitecture () ).append ( ".rpm" );
+            return sb.toString ();
+        }
+    };
+
+    /**
+     * this rpm file name provider follows the standard RPM file name as
+     * {@code <name>-<version>-<release>.<architecture>.rpm}
+     */
+    public static final RpmFileNameProvider DEFAULT_FILENAME_PROVIDER = new RpmFileNameProvider () {
+
+        @Override
+        public String getRpmFileName ( final RpmBuilder rpmBuilder )
+        {
+            final StringBuilder sb = new StringBuilder ( RpmLead.toLeadName ( rpmBuilder.getName (), rpmBuilder.getVersion () ) );
+            sb.append ( '.' ).append ( rpmBuilder.getArchitecture () ).append ( ".rpm" );
+            return sb.toString ();
+        }
+    };
+
     public RpmBuilder ( final String name, final String version, final String release, final Path target ) throws IOException
     {
         this ( name, version, release, "noarch", target );
@@ -754,9 +787,7 @@ public class RpmBuilder implements AutoCloseable
 
     private String makeDefaultFileName ()
     {
-        final StringBuilder sb = new StringBuilder ( RpmLead.toLeadName ( this.name, this.version ) );
-        sb.append ( '-' ).append ( this.architecture ).append ( ".rpm" );
-        return sb.toString ();
+        return this.rpmFileNameProvider.getRpmFileName ( this );
     }
 
     /**
@@ -1141,5 +1172,19 @@ public class RpmBuilder implements AutoCloseable
             this.header.putString ( interpreterTag, interpreter );
             this.header.putString ( scriptTag, script );
         }
+    }
+
+    public void setRpmFileNameProvider ( final RpmFileNameProvider provider )
+    {
+        if ( provider == null )
+        {
+            throw new IllegalArgumentException ( "RPM file name provider must not be null, " );
+        }
+        this.rpmFileNameProvider = provider;
+    }
+
+    public RpmFileNameProvider getRpmFileNameProvider ()
+    {
+        return this.rpmFileNameProvider;
     }
 }

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmFileNameProvider.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmFileNameProvider.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Yariv Amar
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Yariv Amar - initial API
+ *******************************************************************************/
+package org.eclipse.packagedrone.utils.rpm.build;
+
+@FunctionalInterface
+public interface RpmFileNameProvider
+{
+    public String getRpmFileName ( final RpmBuilder rpmBuilder );
+
+}


### PR DESCRIPTION
fix for https://github.com/eclipse/packagedrone/issues/123
- add ability to use custom filename provider
- add 2 providers
 LEGACY_FILENAME_PROVIDER for file name with "-<arch>.rpm"
 DEFAULT_FILENAME_PROVIDER for file name with ".<arch>.rpm" 
- for backwards compatibility the actual default provider is the LEGACY_FILENAME_PROVIDER.
