### PR TITLE
Fix bundles with dir-shape have needed instruction in content.xml (#128)

### DIFF
--- a/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
@@ -131,6 +131,19 @@ public class InstallableUnitTest
         assertThat ( touchpointInstructions, hasEntry ( "manifest", containsString ( fragmentHostEntry ) ) );
     }
 
+    @Test
+    public void platformFilterConvertedToFilter () throws Exception
+    {
+        final String platformFilter = "(&(arc=x68)(os=win32))";
+        final BundleInformation bi = new BundleInformation ();
+        bi.setEclipsePlatformFilter ( platformFilter );
+        final P2MetaDataInformation p2info = new P2MetaDataInformation ();
+
+        final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
+
+        assertThat ( iu.getFilter (), is ( platformFilter ) );
+    }
+
     static private final Matcher<InstallableUnit> hasProvided ( final String namespace, final String name, final String version )
     {
         return new CustomTypeSafeMatcher<InstallableUnit> ( "IU with 'provided'-element [namespace=" + namespace + ", name=" + name + ", version=" + version + " ]" ) {

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
@@ -10,20 +10,20 @@
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.aspect.common.tests;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit;
 import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Entry;
 import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Touchpoint;
 import org.eclipse.packagedrone.repo.aspect.common.p2.P2MetaDataInformation;
 import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation;
+import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.VersionRangedName;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Qualifiers;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Requirement;
@@ -32,89 +32,66 @@ import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Requi
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Test;
+import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class InstallableUnitTest
 {
+    private static final String P2_IU_NAMESPACE = "org.eclipse.equinox.p2.iu";
+
     @Test
     public void test1 ()
     {
+        final boolean notOptional = false;
+        final Boolean nullGreedyBoolean = null;
+        final String noFilter = null;
+        final String bundleId = "b1";
+        final String feature2Id = "f2";
+        final String featureId = "f1";
         final FeatureInformation fi = new FeatureInformation ();
-
-        fi.setId ( "f1" );
+        fi.setId ( featureId );
         fi.setVersion ( Version.parseVersion ( "1.2.3" ) );
         fi.setQualifiers ( new Qualifiers () );
-
-        fi.getRequirements ().add ( new Requirement ( Type.FEATURE, "f2", null, MatchRule.DEFAULT ) );
-        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, "b1", null, MatchRule.DEFAULT ) );
+        fi.getRequirements ().add ( new Requirement ( Type.FEATURE, feature2Id, null, MatchRule.DEFAULT ) );
+        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, bundleId, null, MatchRule.DEFAULT ) );
 
         final List<InstallableUnit> ius = InstallableUnit.fromFeature ( fi );
 
-        assertEquals ( 2, ius.size () );
-
-        assertFeatureGroup1 ( ius.get ( 0 ) );
-        assertFeatureJar1 ( ius.get ( 1 ) );
-    }
-
-    private void assertFeatureJar1 ( final InstallableUnit iu )
-    {
-        assertNotNull ( iu );
-        assertEquals ( "f1.feature.jar", iu.getId () );
-    }
-
-    private void assertFeatureGroup1 ( final InstallableUnit iu )
-    {
-        assertNotNull ( iu );
-        assertEquals ( "f1.feature.group", iu.getId () );
-
-        assertHasRequirementPresent ( iu, "org.eclipse.equinox.p2.iu", "f2.feature.group", 1 );
-        assertHasRequirementPresent ( iu, "org.eclipse.equinox.p2.iu", "b1", 1 );
+        assertThat ( ius.size (), is ( 2 ) );
+        final InstallableUnit iuGrp = ius.get ( 0 );
+        final InstallableUnit iuJar = ius.get ( 1 );
+        assertThat ( iuGrp, hasRequired ( P2_IU_NAMESPACE, feature2Id + ".feature.group", "0.0.0", notOptional, nullGreedyBoolean, noFilter ) );
+        assertThat ( iuGrp, hasRequired ( P2_IU_NAMESPACE, bundleId, "0.0.0", notOptional, nullGreedyBoolean, noFilter ) );
+        assertThat ( iuGrp.getId (), is ( featureId + ".feature.group" ) );
+        assertThat ( iuJar.getId (), is ( featureId + ".feature.jar" ) );
     }
 
     @Test
     public void test2 ()
     {
+        final boolean notOptional = false;
+        final Boolean nullGreedyBoolean = null;
+        final String noFilter = null;
+        final String bundleId = "b1";
+        final String featureId = "f1";
         final FeatureInformation fi = new FeatureInformation ();
-
-        fi.setId ( "f1" );
+        fi.setId ( featureId );
         fi.setVersion ( Version.parseVersion ( "1.2.3" ) );
         fi.setQualifiers ( new Qualifiers () );
-
-        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, "b1", Version.parseVersion ( "1.2.0" ), MatchRule.DEFAULT ) );
-        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, "b1", Version.parseVersion ( "1.3.0" ), MatchRule.DEFAULT ) );
+        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, bundleId, Version.parseVersion ( "1.2.0" ), MatchRule.DEFAULT ) );
+        fi.getRequirements ().add ( new Requirement ( Type.PLUGIN, bundleId, Version.parseVersion ( "1.3.0" ), MatchRule.PERFECT ) );
 
         final List<InstallableUnit> ius = InstallableUnit.fromFeature ( fi );
 
-        assertEquals ( 2, ius.size () );
-
-        assertFeatureGroup2 ( ius.get ( 0 ) );
-        assertFeatureJar2 ( ius.get ( 1 ) );
-    }
-
-    private void assertFeatureJar2 ( final InstallableUnit iu )
-    {
-        assertNotNull ( iu );
-        assertEquals ( "f1.feature.jar", iu.getId () );
-    }
-
-    private void assertFeatureGroup2 ( final InstallableUnit iu )
-    {
-        assertNotNull ( iu );
-        assertEquals ( "f1.feature.group", iu.getId () );
-
-        assertHasRequirementPresent ( iu, "org.eclipse.equinox.p2.iu", "b1", 2 );
-    }
-
-    private static void assertHasRequirementPresent ( final InstallableUnit iu, final String namespace, final String key, final int amount )
-    {
-        final List<Entry<org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement>> req = findRequirement ( iu, namespace, key );
-
-        assertEquals ( amount, req.size () );
-    }
-
-    private static List<Entry<org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement>> findRequirement ( final InstallableUnit iu, final String namespace, final String key )
-    {
-        return iu.getRequires ().stream ().filter ( entry -> entry.getNamespace ().equals ( namespace ) && entry.getKey ().equals ( key ) ).collect ( Collectors.toList () );
+        assertThat ( ius.size (), is ( 2 ) );
+        final InstallableUnit iuGrp = ius.get ( 0 );
+        final InstallableUnit iuJar = ius.get ( 1 );
+        assertThat ( iuGrp, hasRequired ( P2_IU_NAMESPACE, featureId + ".feature.jar", "[1.2.3,1.2.3]", notOptional, nullGreedyBoolean, "(org.eclipse.update.install.features=true)" ) );
+        assertThat ( iuGrp, hasRequired ( P2_IU_NAMESPACE, bundleId, "0.0.0", notOptional, nullGreedyBoolean, noFilter ) );
+        assertThat ( iuGrp, hasRequired ( P2_IU_NAMESPACE, bundleId, "[1.3.0,1.3.0]", notOptional, nullGreedyBoolean, noFilter ) );
+        assertThat ( iuGrp.getId (), is ( featureId + ".feature.group" ) );
+        assertThat ( iuJar.getId (), is ( featureId + ".feature.jar" ) );
     }
 
     @Test
@@ -127,17 +104,87 @@ public class InstallableUnitTest
         final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
 
         final Touchpoint touchpoint = iu.getTouchpoints ().get ( 0 );
-        assertThat ( touchpoint.getInstructions (), hasEntry ( "zipped", "true" ) );
+        assertThat ( touchpoint.getInstructions (), hasEntry ( "zipped", is ( "true" ) ) );
     }
 
-    static private final Matcher<Map<?, ?>> hasEntry ( final Object key, final Object value )
+    @Test
+    public void fragmentSpecificPropertiesAddedToIU () throws Exception
     {
-        return new CustomTypeSafeMatcher<Map<?, ?>> ( "" ) {
+        final boolean notOptional = false;
+        final Boolean nullGreedyBoolean = null;
+        final String noFilter = null;
+        final String hostBundleName = "org.host.bundle";
+        final String ownVersion = "1.0.7";
+        final String hostVersionRange = "[1.0.1,2.0.0)";
+        final VersionRangedName hostBundle = new VersionRangedName ( hostBundleName, VersionRange.valueOf ( hostVersionRange ) );
+        final BundleInformation bi = new BundleInformation ();
+        bi.setFragmentHost ( hostBundle );
+        bi.setVersion ( Version.parseVersion ( ownVersion ) );
+        final P2MetaDataInformation p2info = new P2MetaDataInformation ();
+
+        final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
+
+        assertThat ( iu, hasProvided ( "osgi.fragment", hostBundleName, ownVersion ) );
+        assertThat ( iu, hasRequired ( "osgi.bundle", hostBundleName, hostVersionRange, notOptional, nullGreedyBoolean, noFilter ) );
+        final String fragmentHostEntry = Constants.FRAGMENT_HOST + ": " + hostBundleName + ";" + Constants.BUNDLE_VERSION_ATTRIBUTE + "=\"" + hostVersionRange + "\"";
+        final Map<String, String> touchpointInstructions = iu.getTouchpoints ().get ( 0 ).getInstructions ();
+        assertThat ( touchpointInstructions, hasEntry ( "manifest", containsString ( fragmentHostEntry ) ) );
+    }
+
+    static private final Matcher<InstallableUnit> hasProvided ( final String namespace, final String name, final String version )
+    {
+        return new CustomTypeSafeMatcher<InstallableUnit> ( "IU with 'provided'-element [namespace=" + namespace + ", name=" + name + ", version=" + version + " ]" ) {
 
             @Override
-            protected boolean matchesSafely ( final Map<?, ?> item )
+            protected boolean matchesSafely ( final InstallableUnit item )
             {
-                if ( Objects.equals ( item.get ( key ), value ) )
+                final List<Entry<String>> provides = item.getProvides ();
+                for ( final Entry<String> provide : provides )
+                {
+                    if ( Objects.equals ( provide.getNamespace (), namespace ) && Objects.equals ( provide.getKey (), name ) && Objects.equals ( provide.getValue (), version ) )
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+
+    static private final Matcher<InstallableUnit> hasRequired ( final String namespace, final String name, final String versionRange, final boolean isOptional, final Boolean greedy, final String filter )
+    {
+        return new CustomTypeSafeMatcher<InstallableUnit> ( "IU with 'required'-element [namespace= " + namespace + ", name= " + name + ", versionRange= " + versionRange + " ]" ) {
+
+            @Override
+            protected boolean matchesSafely ( final InstallableUnit item )
+            {
+                final List<Entry<org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement>> requires = item.getRequires ();
+                for ( final Entry<org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement> require : requires )
+                {
+
+                    if ( Objects.equals ( require.getNamespace (), namespace ) && Objects.equals ( require.getKey (), name ) )
+                    {
+                        final org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement value = require.getValue ();
+                        if ( Objects.equals ( value.getRange (), VersionRange.valueOf ( versionRange ) ) && Objects.equals ( value.getFilter (), filter ) && Objects.equals ( value.getGreedy (), greedy ) )
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        };
+    }
+
+    static private final <K, V> Matcher<Map<K, V>> hasEntry ( final K key, final Matcher<V> valueMatcher )
+    {
+        return new CustomTypeSafeMatcher<Map<K, V>> ( "Map with entry: key=" + key + ", value=" + valueMatcher ) {
+
+            @Override
+            protected boolean matchesSafely ( final Map<K, V> item )
+            {
+                final Object actualValue = item.get ( key );
+                if ( valueMatcher.matches ( actualValue ) )
                 {
                     return true;
                 }

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
@@ -10,19 +10,27 @@
  *******************************************************************************/
 package org.eclipse.packagedrone.repo.aspect.common.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit;
 import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Entry;
+import org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Touchpoint;
+import org.eclipse.packagedrone.repo.aspect.common.p2.P2MetaDataInformation;
+import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Qualifiers;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Requirement;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Requirement.MatchRule;
 import org.eclipse.packagedrone.repo.utils.osgi.feature.FeatureInformation.Requirement.Type;
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.osgi.framework.Version;
 
@@ -107,5 +115,34 @@ public class InstallableUnitTest
     private static List<Entry<org.eclipse.packagedrone.repo.aspect.common.p2.InstallableUnit.Requirement>> findRequirement ( final InstallableUnit iu, final String namespace, final String key )
     {
         return iu.getRequires ().stream ().filter ( entry -> entry.getNamespace ().equals ( namespace ) && entry.getKey ().equals ( key ) ).collect ( Collectors.toList () );
+    }
+
+    @Test
+    public void addsZippedInstructionOnDirShape () throws Exception
+    {
+        final P2MetaDataInformation p2info = new P2MetaDataInformation ();
+        final BundleInformation bi = new BundleInformation ();
+        bi.setEclipseBundleShape ( "dir" );
+
+        final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
+
+        final Touchpoint touchpoint = iu.getTouchpoints ().get ( 0 );
+        assertThat ( touchpoint.getInstructions (), hasEntry ( "zipped", "true" ) );
+    }
+
+    static private final Matcher<Map<?, ?>> hasEntry ( final Object key, final Object value )
+    {
+        return new CustomTypeSafeMatcher<Map<?, ?>> ( "" ) {
+
+            @Override
+            protected boolean matchesSafely ( final Map<?, ?> item )
+            {
+                if ( Objects.equals ( item.get ( key ), value ) )
+                {
+                    return true;
+                }
+                return false;
+            }
+        };
     }
 }

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common.tests/src/org/eclipse/packagedrone/repo/aspect/common/tests/InstallableUnitTest.java
@@ -12,6 +12,7 @@ package org.eclipse.packagedrone.repo.aspect.common.tests;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
@@ -142,6 +143,32 @@ public class InstallableUnitTest
         final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
 
         assertThat ( iu.getFilter (), is ( platformFilter ) );
+    }
+
+    @Test
+    public void providesTypeBundle () throws Exception
+    {
+        final BundleInformation bi = new BundleInformation ();
+        bi.setSourceBunde ( false );
+        final P2MetaDataInformation p2info = new P2MetaDataInformation ();
+
+        final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
+
+        assertThat ( iu, hasProvided ( "org.eclipse.equinox.p2.eclipse.type", "bundle", "1.0.0" ) );
+        assertThat ( iu, not ( hasProvided ( "org.eclipse.equinox.p2.eclipse.type", "source", "1.0.0" ) ) );
+    }
+
+    @Test
+    public void providesTypeSource () throws Exception
+    {
+        final BundleInformation bi = new BundleInformation ();
+        bi.setSourceBunde ( true );
+        final P2MetaDataInformation p2info = new P2MetaDataInformation ();
+
+        final InstallableUnit iu = InstallableUnit.fromBundle ( bi, p2info );
+
+        assertThat ( iu, hasProvided ( "org.eclipse.equinox.p2.eclipse.type", "source", "1.0.0" ) );
+        assertThat ( iu, not ( hasProvided ( "org.eclipse.equinox.p2.eclipse.type", "bundle", "1.0.0" ) ) );
     }
 
     static private final Matcher<InstallableUnit> hasProvided ( final String namespace, final String name, final String version )

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Channel Aspects
 Bundle-SymbolicName: org.eclipse.packagedrone.repo.aspect.common
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Jens Reimann
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.google.common.hash;version="18.0.0",
@@ -23,7 +23,7 @@ Import-Package: com.google.common.hash;version="18.0.0",
  org.eclipse.packagedrone.repo.aspect.virtual;version="1.0.0",
  org.eclipse.packagedrone.repo.channel;version="1.0.0",
  org.eclipse.packagedrone.repo.utils;version="1.0.0",
- org.eclipse.packagedrone.repo.utils.osgi.bundle;version="1.0.0",
+ org.eclipse.packagedrone.repo.utils.osgi.bundle;version="[1.1.0,2.0.0)",
  org.eclipse.packagedrone.repo.utils.osgi.feature;version="1.0.0",
  org.eclipse.packagedrone.repo.xml;version="1.0.0",
  org.eclipse.packagedrone.utils;version="1.0.0",
@@ -49,7 +49,7 @@ Export-Package: org.eclipse.packagedrone.repo.aspect.common.osgi;version="1.0.0"
    org.eclipse.packagedrone.repo.aspect.extract,
    org.eclipse.packagedrone.repo.utils.osgi.bundle,
    org.eclipse.packagedrone.repo.utils.osgi.feature",
- org.eclipse.packagedrone.repo.aspect.common.p2;version="1.0.0";
+ org.eclipse.packagedrone.repo.aspect.common.p2;version="1.0.1";
   uses:="org.osgi.framework,
    org.eclipse.packagedrone.repo.aspect,
    org.eclipse.packagedrone.repo,

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
@@ -590,6 +590,8 @@ public class InstallableUnit
             logger.warn ( "Failed to generate manifest", e );
         }
 
+        result.setFilter ( bundle.getEclipsePlatformFilter () );
+
         return result;
     }
 

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
@@ -504,7 +504,7 @@ public class InstallableUnit
 
     public static InstallableUnit fromBundle ( final BundleInformation bundle )
     {
-        return fromBundle ( bundle, null );
+        return fromBundle ( bundle, new P2MetaDataInformation () );
     }
 
     public static InstallableUnit fromBundle ( final BundleInformation bundle, final P2MetaDataInformation info )
@@ -561,8 +561,12 @@ public class InstallableUnit
 
         try
         {
-            final Map<String, String> td = new HashMap<String, String> ( 1 );
+            final Map<String, String> td = new HashMap<> ( 1 );
             td.put ( "manifest", makeManifest ( bundle.getId (), bundle.getVersion () ) );
+            if ( "dir".equals ( bundle.getEclipseBundleShape () ) )
+            {
+                td.put ( "zipped", "true" );
+            }
             result.getTouchpoints ().add ( new Touchpoint ( "org.eclipse.equinox.p2.osgi", "1.0.0", td ) );
         }
         catch ( final Exception e )
@@ -599,7 +603,7 @@ public class InstallableUnit
 
     /**
      * Add property entry only of value is not null
-     * 
+     *
      * @param props
      *            properties
      * @param key
@@ -665,7 +669,7 @@ public class InstallableUnit
 
     /**
      * Write a list of units inside a {@code units} element
-     * 
+     *
      * @param xsw
      *            the stream to write to
      * @param ius
@@ -686,7 +690,7 @@ public class InstallableUnit
 
     /**
      * Write a single unit inside a {@code units} element
-     * 
+     *
      * @param xsw
      *            the stream to write to
      * @throws XMLStreamException
@@ -699,7 +703,7 @@ public class InstallableUnit
 
     /**
      * Write the unit as XML fragment
-     * 
+     *
      * @param xsw
      *            the XMLStreamWriter to write to
      * @throws XMLStreamException

--- a/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
+++ b/bundles/org.eclipse.packagedrone.repo.aspect.common/src/org/eclipse/packagedrone/repo/aspect/common/p2/InstallableUnit.java
@@ -532,8 +532,14 @@ public class InstallableUnit
 
         addProvides ( result, "osgi.bundle", bundle.getId (), "" + bundle.getVersion () );
         addProvides ( result, "org.eclipse.equinox.p2.iu", bundle.getId (), "" + bundle.getVersion () );
-        addProvides ( result, "org.eclipse.equinox.p2.eclipse.type", "bundle", "1.0.0" );
-
+        if ( bundle.isSourceBundle () )
+        {
+            addProvides ( result, "org.eclipse.equinox.p2.eclipse.type", "source", "1.0.0" );
+        }
+        else
+        {
+            addProvides ( result, "org.eclipse.equinox.p2.eclipse.type", "bundle", "1.0.0" );
+        }
         for ( final PackageExport pe : bundle.getPackageExports () )
         {
             addProvides ( result, "java.package", pe.getName (), makeVersion ( pe.getVersion () ) );

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OSGi core functionalities
 Bundle-SymbolicName: org.eclipse.packagedrone.repo.utils.osgi
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Jens Reimann
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.packagedrone.repo.utils.osgi;version="1.0.0",
- org.eclipse.packagedrone.repo.utils.osgi.bundle;version="1.0.0",
+ org.eclipse.packagedrone.repo.utils.osgi.bundle;version="1.1.0",
  org.eclipse.packagedrone.repo.utils.osgi.feature;version="1.0.0"
 Import-Package: com.google.gson;version="2.3.1",
  com.google.gson.stream;version="2.3.1",

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
@@ -440,6 +440,8 @@ public class BundleInformation implements TranslatedInformation
 
     private String eclipsePlatformFilter;
 
+    private boolean sourceBundle;
+
     public void setEclipseBundleShape ( final String eclipseBundleShape )
     {
         this.eclipseBundleShape = eclipseBundleShape;
@@ -655,5 +657,15 @@ public class BundleInformation implements TranslatedInformation
     public String toJson ()
     {
         return ParserHelper.newGson ().toJson ( this );
+    }
+
+    public void setSourceBunde ( final boolean source )
+    {
+        this.sourceBundle = source;
+    }
+
+    public boolean isSourceBundle ()
+    {
+        return this.sourceBundle;
     }
 }

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
@@ -438,6 +438,8 @@ public class BundleInformation implements TranslatedInformation
 
     private List<RequireCapability> requiredCapabilities = new LinkedList<> ();
 
+    private String eclipsePlatformFilter;
+
     public void setEclipseBundleShape ( final String eclipseBundleShape )
     {
         this.eclipseBundleShape = eclipseBundleShape;
@@ -624,6 +626,16 @@ public class BundleInformation implements TranslatedInformation
     public List<RequireCapability> getRequiredCapabilities ()
     {
         return this.requiredCapabilities;
+    }
+
+    public void setEclipsePlatformFilter ( final String eclipsePlatformFilter )
+    {
+        this.eclipsePlatformFilter = eclipsePlatformFilter;
+    }
+
+    public String getEclipsePlatformFilter ()
+    {
+        return this.eclipsePlatformFilter;
     }
 
     public static BundleInformation fromJson ( final String string )

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
@@ -30,6 +30,9 @@ public class BundleInformation implements TranslatedInformation
 {
     public static final MetaKey META_KEY = new MetaKey ( "osgi", "bundle-information" );
 
+    /**
+     * @since 1.1
+     */
     public static class VersionRangedName
     {
         protected final String name;
@@ -549,11 +552,17 @@ public class BundleInformation implements TranslatedInformation
         return this.singleton;
     }
 
+    /**
+     * @since 1.1
+     */
     public VersionRangedName getFragmentHost ()
     {
         return this.fragmentHost;
     }
 
+    /**
+     * @since 1.1
+     */
     public void setFragmentHost ( final VersionRangedName fragmentHost )
     {
         this.fragmentHost = fragmentHost;
@@ -630,11 +639,17 @@ public class BundleInformation implements TranslatedInformation
         return this.requiredCapabilities;
     }
 
+    /**
+     * @since 1.1
+     */
     public void setEclipsePlatformFilter ( final String eclipsePlatformFilter )
     {
         this.eclipsePlatformFilter = eclipsePlatformFilter;
     }
 
+    /**
+     * @since 1.1
+     */
     public String getEclipsePlatformFilter ()
     {
         return this.eclipsePlatformFilter;
@@ -659,11 +674,17 @@ public class BundleInformation implements TranslatedInformation
         return ParserHelper.newGson ().toJson ( this );
     }
 
+    /**
+     * @since 1.1
+     */
     public void setSourceBunde ( final boolean source )
     {
         this.sourceBundle = source;
     }
 
+    /**
+     * @since 1.1
+     */
     public boolean isSourceBundle ()
     {
         return this.sourceBundle;

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformation.java
@@ -30,19 +30,16 @@ public class BundleInformation implements TranslatedInformation
 {
     public static final MetaKey META_KEY = new MetaKey ( "osgi", "bundle-information" );
 
-    public static class PackageImport
+    public static class VersionRangedName
     {
-        private final String name;
+        protected final String name;
 
-        private final VersionRange versionRange;
+        protected final VersionRange versionRange;
 
-        private final boolean optional;
-
-        public PackageImport ( final String name, final VersionRange versionRange, final boolean optional )
+        public VersionRangedName ( final String name, final VersionRange versionRange )
         {
             this.name = name;
             this.versionRange = versionRange;
-            this.optional = optional;
         }
 
         public String getName ()
@@ -53,6 +50,80 @@ public class BundleInformation implements TranslatedInformation
         public VersionRange getVersionRange ()
         {
             return this.versionRange;
+        }
+
+        @Override
+        public int hashCode ()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ( this.name == null ? 0 : this.name.hashCode () );
+            result = prime * result + ( this.versionRange == null ? 0 : this.versionRange.hashCode () );
+            return result;
+        }
+
+        @Override
+        public boolean equals ( final Object obj )
+        {
+            if ( this == obj )
+            {
+                return true;
+            }
+            if ( obj == null )
+            {
+                return false;
+            }
+            if ( getClass () != obj.getClass () )
+            {
+                return false;
+            }
+            final VersionRangedName other = (VersionRangedName)obj;
+            if ( this.name == null )
+            {
+                if ( other.name != null )
+                {
+                    return false;
+                }
+            }
+            else if ( !this.name.equals ( other.name ) )
+            {
+                return false;
+            }
+            if ( this.versionRange == null )
+            {
+                if ( other.versionRange != null )
+                {
+                    return false;
+                }
+            }
+            else if ( !this.versionRange.equals ( other.versionRange ) )
+            {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString ()
+        {
+            if ( this.versionRange != null )
+            {
+                return this.name + ";version=\"" + this.versionRange.getLeftType () + this.versionRange.getLeft () + "," + this.versionRange.getRight () + this.versionRange.getRightType () + "\"";
+            }
+            return this.name;
+        }
+
+    }
+
+    public static class PackageImport extends VersionRangedName
+    {
+
+        private final boolean optional;
+
+        public PackageImport ( final String name, final VersionRange versionRange, final boolean optional )
+        {
+            super ( name, versionRange );
+            this.optional = optional;
         }
 
         public boolean isOptional ()
@@ -80,7 +151,7 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( this.getClass() != obj.getClass() )
+            if ( this.getClass () != obj.getClass () )
             {
                 return false;
             }
@@ -157,7 +228,7 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( this.getClass() != obj.getClass() )
+            if ( this.getClass () != obj.getClass () )
             {
                 return false;
             }
@@ -184,11 +255,8 @@ public class BundleInformation implements TranslatedInformation
 
     }
 
-    public static class BundleRequirement
+    public static class BundleRequirement extends VersionRangedName
     {
-        private final String id;
-
-        private final VersionRange versionRange;
 
         private final boolean optional;
 
@@ -196,20 +264,14 @@ public class BundleInformation implements TranslatedInformation
 
         public BundleRequirement ( final String id, final VersionRange versionRange, final boolean optional, final boolean reexport )
         {
-            this.id = id;
-            this.versionRange = versionRange;
+            super ( id, versionRange );
             this.optional = optional;
             this.reexport = reexport;
         }
 
         public String getId ()
         {
-            return this.id;
-        }
-
-        public VersionRange getVersionRange ()
-        {
-            return this.versionRange;
+            return this.name;
         }
 
         public boolean isOptional ()
@@ -227,7 +289,7 @@ public class BundleInformation implements TranslatedInformation
         {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ( this.id == null ? 0 : this.id.hashCode () );
+            result = prime * result + ( this.name == null ? 0 : this.name.hashCode () );
             return result;
         }
 
@@ -242,19 +304,19 @@ public class BundleInformation implements TranslatedInformation
             {
                 return false;
             }
-            if ( this.getClass() != obj.getClass() )
+            if ( this.getClass () != obj.getClass () )
             {
                 return false;
             }
             final BundleRequirement other = (BundleRequirement)obj;
-            if ( this.id == null )
+            if ( this.name == null )
             {
-                if ( other.id != null )
+                if ( other.name != null )
                 {
                     return false;
                 }
             }
-            else if ( !this.id.equals ( other.id ) )
+            else if ( !this.name.equals ( other.name ) )
             {
                 return false;
             }
@@ -355,6 +417,8 @@ public class BundleInformation implements TranslatedInformation
     private String description;
 
     private boolean singleton;
+
+    private VersionRangedName fragmentHost;
 
     private String bundleLocalization;
 
@@ -479,6 +543,16 @@ public class BundleInformation implements TranslatedInformation
     public boolean isSingleton ()
     {
         return this.singleton;
+    }
+
+    public VersionRangedName getFragmentHost ()
+    {
+        return this.fragmentHost;
+    }
+
+    public void setFragmentHost ( final VersionRangedName fragmentHost )
+    {
+        this.fragmentHost = fragmentHost;
     }
 
     @Override

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
@@ -113,6 +113,7 @@ public class BundleInformationParser
         result.setEclipseBundleShape ( ma.getValue ( "Eclipse-BundleShape" ) );
 
         result.setRequiredExecutionEnvironments ( Headers.parseStringList ( ma.getValue ( Constants.BUNDLE_REQUIREDEXECUTIONENVIRONMENT ) ) );
+        result.setEclipsePlatformFilter ( ma.getValue ( "Eclipse-PlatformFilter" ) );
 
         processImportPackage ( result, ma );
         processExportPackage ( result, ma );

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
@@ -29,6 +29,7 @@ import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.Package
 import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.PackageImport;
 import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.ProvideCapability;
 import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.RequireCapability;
+import org.eclipse.packagedrone.repo.utils.osgi.bundle.BundleInformation.VersionRangedName;
 import org.eclipse.packagedrone.utils.AttributedValue;
 import org.eclipse.packagedrone.utils.Headers;
 import org.osgi.framework.Constants;
@@ -81,9 +82,17 @@ public class BundleInformationParser
         {
             return null;
         }
+        final AttributedValue fragmentHost = Headers.parse ( ma.getValue ( Constants.FRAGMENT_HOST ) );
+        if ( fragmentHost != null )
+        {
+            final String bundleSymbolicName = fragmentHost.getValue ();
+            final String rangeStr = fragmentHost.getAttributes ().get ( Constants.BUNDLE_VERSION_ATTRIBUTE );
+            final VersionRange versionRange = rangeStr != null ? new VersionRange ( rangeStr ) : null;
+            result.setFragmentHost ( new VersionRangedName ( bundleSymbolicName, versionRange ) );
+        }
 
         result.setId ( id.getValue () );
-        result.setSingleton ( Boolean.parseBoolean ( id.getAttributes ().get ( "singleton" ) ) );
+        result.setSingleton ( Boolean.parseBoolean ( id.getAttributes ().get ( Constants.SINGLETON_DIRECTIVE ) ) );
 
         try
         {

--- a/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
+++ b/bundles/org.eclipse.packagedrone.repo.utils.osgi/src/org/eclipse/packagedrone/repo/utils/osgi/bundle/BundleInformationParser.java
@@ -114,6 +114,7 @@ public class BundleInformationParser
 
         result.setRequiredExecutionEnvironments ( Headers.parseStringList ( ma.getValue ( Constants.BUNDLE_REQUIREDEXECUTIONENVIRONMENT ) ) );
         result.setEclipsePlatformFilter ( ma.getValue ( "Eclipse-PlatformFilter" ) );
+        result.setSourceBunde ( ma.getValue ( "Eclipse-SourceBundle" ) != null );
 
         processImportPackage ( result, ma );
         processExportPackage ( result, ma );


### PR DESCRIPTION
When a bundles has the Eclipse-BundleShape: dir manifest entry the
installable unit in content.xml the touchpointData must have
<instruction key='zipped'>true</instruction>
Otherwise when tycho builds a product the bundle is not beeing
extracted.