### PR TITLE
Add support for custom charset in header data

### DIFF
--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/BuilderOptions.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/BuilderOptions.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.packagedrone.utils.rpm.build;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -37,6 +39,8 @@ public class BuilderOptions
 
     private DigestAlgorithm fileDigestAlgorithm = DigestAlgorithm.MD5;
 
+    private Charset headerCharset = StandardCharsets.UTF_8;
+
     public BuilderOptions ()
     {
     }
@@ -48,6 +52,7 @@ public class BuilderOptions
         setPayloadCoding ( other.payloadCoding );
         setPayloadFlags ( other.payloadFlags );
         setFileDigestAlgorithm ( other.fileDigestAlgorithm );
+        setHeaderCharset ( other.headerCharset );
     }
 
     public LongMode getLongMode ()
@@ -116,5 +121,15 @@ public class BuilderOptions
     public void setFileDigestAlgorithm ( final DigestAlgorithm fileDigestAlgorithm )
     {
         this.fileDigestAlgorithm = fileDigestAlgorithm == null ? DigestAlgorithm.MD5 : fileDigestAlgorithm;
+    }
+
+    public Charset getHeaderCharset ()
+    {
+        return this.headerCharset;
+    }
+
+    public void setHeaderCharset ( final Charset headerCharset )
+    {
+        this.headerCharset = headerCharset == null ? StandardCharsets.UTF_8 : headerCharset;
     }
 }

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmBuilder.java
@@ -1074,7 +1074,7 @@ public class RpmBuilder implements AutoCloseable
             this.headerCustomizer.accept ( this.header );
         }
 
-        try ( final RpmWriter writer = new RpmWriter ( this.targetFile, leadBuilder, this.header, this.options.getOpenOptions () ) )
+        try ( final RpmWriter writer = new RpmWriter ( this.targetFile, leadBuilder, this.header, this.options.getHeaderCharset (), this.options.getOpenOptions () ) )
         {
             writer.addAllSignatureProcessors ( this.signatureProcessors );
             writer.setPayload ( this.recorder );

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmWriter.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/build/RpmWriter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -65,21 +66,27 @@ public class RpmWriter implements AutoCloseable
 
     private final List<SignatureProcessor> signatureProcessors = new LinkedList<> ();
 
-    public RpmWriter ( final Path path, final Supplier<RpmLead> leadProvider, final Header<RpmTag> header, final OpenOption... options ) throws IOException
+    public RpmWriter ( final Path path, final Supplier<RpmLead> leadProvider, final Header<RpmTag> header, final Charset headerCharset, final OpenOption... options ) throws IOException
     {
         requireNonNull ( path );
         requireNonNull ( leadProvider );
         requireNonNull ( header );
+        requireNonNull ( headerCharset );
 
         this.file = FileChannel.open ( path, options != null && options.length > 0 ? options : DEFAULT_OPEN_OPTIONS );
         this.lead = leadProvider.get ();
 
-        this.header = Headers.render ( header.makeEntries (), true, Rpms.IMMUTABLE_TAG_HEADER );
+        this.header = Headers.render ( header.makeEntries (headerCharset), true, Rpms.IMMUTABLE_TAG_HEADER );
     }
 
     public RpmWriter ( final Path path, final LeadBuilder leadBuilder, final Header<RpmTag> header, final OpenOption... options ) throws IOException
     {
-        this ( path, leadBuilder::build, header, options );
+        this ( path, leadBuilder::build, header, StandardCharsets.UTF_8, options );
+    }
+
+    public RpmWriter ( final Path path, final LeadBuilder leadBuilder, final Header<RpmTag> header, final Charset headerCharset, final OpenOption... options ) throws IOException
+    {
+        this ( path, leadBuilder::build, header, headerCharset, options );
     }
 
     public void addSignatureProcessor ( final SignatureProcessor processor )

--- a/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/header/Header.java
+++ b/bundles/org.eclipse.packagedrone.utils.rpm/src/org/eclipse/packagedrone/utils/rpm/header/Header.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,6 +61,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T>
     }
 
     private final Map<Integer, Object> entries = new LinkedHashMap<> ();
+    private static Charset charset = StandardCharsets.UTF_8;
 
     public Header ( final HeaderEntry[] entries )
     {
@@ -290,6 +292,27 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T>
         return Optional.ofNullable ( get ( tag ) );
     }
 
+
+    /**
+     * Make an array of header entries with given charset
+     * <p>
+     * <strong>Note:</strong> Further updates on this instance will not update
+     * the returned array. This is actually a copy of the current state.
+     * </p>
+     *
+     * @param charset the charset of choice
+     * @return a new array of all header entries, unsorted
+     */
+    public HeaderEntry[] makeEntries ( Charset charset )
+    {
+        if ( charset == null )
+        {
+            throw new IllegalArgumentException ( "'charset' cannot be null" );
+        }
+        Header.charset = charset;
+        return this.entries.entrySet ().stream ().map ( Header::makeEntry ).toArray ( num -> new HeaderEntry[num] );
+    }
+
     /**
      * Make an array of header entries
      * <p>
@@ -301,7 +324,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T>
      */
     public HeaderEntry[] makeEntries ()
     {
-        return this.entries.entrySet ().stream ().map ( Header::makeEntry ).toArray ( num -> new HeaderEntry[num] );
+        return makeEntries ( StandardCharsets.UTF_8 );
     }
 
     private static HeaderEntry makeEntry ( final Map.Entry<Integer, Object> entry )
@@ -433,7 +456,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T>
         {
             if ( string != null )
             {
-                out.write ( string.getBytes ( StandardCharsets.UTF_8 ) );
+                out.write ( string.getBytes (charset) );
             }
             out.write ( 0 );
         }


### PR DESCRIPTION
I would like to add a possibility of charset customization in header. Sometimes I have to create RPMs for platforms where UTF-8 is not supported. And using non Latin characters results in broken symbols.